### PR TITLE
RELATED: BB-1407 Document relation between sorting and subtotals.

### DIFF
--- a/docs/table_totals.md
+++ b/docs/table_totals.md
@@ -96,13 +96,13 @@ return (
 
 A subtotal aggregates data for all values in an attribute group. A subtotal is displayed as a regular table row with data and is not pinned to the bottom of the table.
 
-**NOTE:** Although the Execute component supports both grand totals and sub totals on any dimension, the Table component supports only grand totals on rows.
-
 A subtotal is defined the same way a grant total is, except `attributeIdentifier` is defined by the attribute that is being grouped.
+
+**NOTE:** Although the Execute component supports both grand totals and subtotals on any dimension, the Table component supports only grand totals on rows. In addition, the subtotals are supported only for tables sorted by the first row attribute, and this is the default sorting for tables.
 
 **Example:**
 
-![Sub Totals for Columns](assets/pivot_table_subtotals.png)
+![Subtotals for Columns](assets/pivot_table_subtotals.png)
 
 ```jsx
 const measures = [


### PR DESCRIPTION
The wording of the new sentence ("In addition, the subtotals are supported only for tables sorted by the first row attribute, and this is the default sorting for tables.") was approved by @evgeniabogranskaya 