### PR TITLE
BUGFIX: ONE-4190 fixed Angular 2+ documentation page

### DIFF
--- a/website/versioned_docs/version-6.3.0/ht_use_react_components_in_angular_2.x.md
+++ b/website/versioned_docs/version-6.3.0/ht_use_react_components_in_angular_2.x.md
@@ -2,13 +2,15 @@
 title: Use Angular 2+
 sidebar_label: Use Angular 2+
 copyright: (C) 2007-2018 GoodData Corporation
-id: ht_use_react_component_in_angular_2.x
+id: version-6.3.0-ht_use_react_component_in_angular_2.x
+original_id: ht_use_react_component_in_angular_2.x
 ---
 
 To be able to use the GoodData.UI Visual Components in your Angular 2+ environment, wrap each component into an Angular component, and then render the React component using `ReactDom.render` inside.
 
 ## 1. Install dependencies
-<!-- 
+
+<!--
     For GDC developer:
     - Install ng cli using `npm install -g @angular/cli` or `yarn global add @angular/cli` and create angular app with `ng new my-sba-app`.
     - Add proxy.conf.json:
@@ -37,14 +39,16 @@ To be able to use the GoodData.UI Visual Components in your Angular 2+ environm
     - open https://localhost:4200/account.html
     - add KpiComponent to app.module.ts section NgModule.declarations
  -->
- 
+
 Install latest dependencies using either `npm` or `yarn`. Your application must be able to render React components from `@gooddata/react-components` using a unique ID \(`uuid`\), and you also must be able to issue an `invariant` exception if the DOM node is not available.
 
 ```bash
 npm install --save uuid invariant react@^16.5.2 react-dom@^16.5.2 @gooddata/react-components rxjs-compat@6
 npm install --save-dev @types/react @types/react-intl@2.3.8
 ```
+
 or
+
 ```bash
 yarn add uuid invariant react@^16.5.2 react-dom@^16.5.2 @gooddata/react-components rxjs-compat@6
 yarn add @types/react @types/react-intl@2.3.8 --dev
@@ -53,14 +57,16 @@ yarn add @types/react @types/react-intl@2.3.8 --dev
 **NOTE:** When using Angular 6+, be sure to add the `(window as any).global = window;` snippet to the `polyfills.ts` file due to missing `global`.
 
 ## 2. Declare the Angular wrapper component
+
 The Angular wrapper component renders a React component and re-renders it on a property change.
 
-The component wrapper must be able to render React components imported from `@gooddata/react-components`. 
-You can import any supported components from the package, and then either put them together using multiple `React.createElement` functions, or make an abstract wrapper component that accepts a React component reference as a parameter. 
+The component wrapper must be able to render React components imported from `@gooddata/react-components`.
+You can import any supported components from the package, and then either put them together using multiple `React.createElement` functions, or make an abstract wrapper component that accepts a React component reference as a parameter.
 
 The following examples are using a single KPI component.
 
 **kpi.component.ts**:
+
 ```javascript
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
@@ -152,78 +158,81 @@ If you want to render some charts, do the following:
 
 1. Use a root dom node with the size defined:
 
-    **columnchart.component.ts**:
-    ```javascript
-    ...
-    
-    import { ColumnChart } from '@gooddata/react-components';
-    
-    ...
-    
-    @Component({
-      selector: 'app-column-chart',
-      template: '<div style="height: 300px" [id]="rootDomID"></div>'
-    })
-    
-    ...
-    }
-    ```
+   **columnchart.component.ts**:
+
+   ```javascript
+   ...
+
+   import { ColumnChart } from '@gooddata/react-components';
+
+   ...
+
+   @Component({
+     selector: 'app-column-chart',
+     template: '<div style="height: 300px" [id]="rootDomID"></div>'
+   })
+
+   ...
+   }
+   ```
 
 2. Import the `main.css` file from `@gooddata/react-components` to your global styles:
 
-    **styles.css**:
-    ```css
-    @import "@gooddata/react-components/styles/css/main.css"
-    
-    ```
+   **styles.css**:
 
-    or
+   ```css
+   @import "@gooddata/react-components/styles/css/main.css";
+   ```
 
-    **angular.json**:
-    ```json
-    {
-      ...
-      "architect": {
-          "build": {
-              "builder": "@angular-devkit/build-angular:browser",
-              "options": {
-    
-                "styles": [
-                  "src/styles.css",
-                  "node_modules/@gooddata/react-components/styles/css/main.css"
-                ],
-                "scripts": []
-              },
-              ...
-          }
-      ...
-    }
-    
-    ```
+   or
+
+   **angular.json**:
+
+   ```json
+   {
+     ...
+     "architect": {
+         "build": {
+             "builder": "@angular-devkit/build-angular:browser",
+             "options": {
+
+               "styles": [
+                 "src/styles.css",
+                 "node_modules/@gooddata/react-components/styles/css/main.css"
+               ],
+               "scripts": []
+             },
+             ...
+         }
+     ...
+   }
+
+   ```
 
 **NOTE:** If you are using the `PivotTable` component, import the `pivotTable.css` file into your global styles.
 
 For more details about importing global styles in an Angular app, see the [Angular documentation](https://angular.io/guide/workspace-config#styles-and-scripts-configuration).
 
-**NOTE:** When this article was last updated, there was an [outstanding issue in Angular 4](https://github.com/angular/angular/issues/14252). `ngOnDestroy` is called _after_ a DOM node has already been removed. Not calling `ReactDOM.unmountComponentAtNode(this.getRootDomNode())` results in memory leaks.
+**NOTE:** When this article was last updated, there was an [outstanding issue in Angular 4](https://github.com/angular/angular/issues/14252). `ngOnDestroy` is called *after* a DOM node has already been removed. Not calling `ReactDOM.unmountComponentAtNode(this.getRootDomNode())` results in memory leaks.
 
 Verify whether the issue is present in your version of Angular. If not, uncomment the commented-out line in `ngOnDestroy`.
 
 ## 3. Use the component
+
 You are now ready to use the GoodData React components in your Angular app.
 
 You can use wrapped components across your app, pass the component props to it, and even update them using data-binding.
 
 ```javascript
 <app-kpi
-    projectId="la84vcyhrq8jwbu4wpipw66q2sqeb923"
-    measure="atSHqCtAePe4">
-</app-kpi>
+  projectId="la84vcyhrq8jwbu4wpipw66q2sqeb923"
+  measure="atSHqCtAePe4"
+></app-kpi>
 ```
 
 If you want to handle loading and error content yourself, and you do not want to use the default LoadingComponent and ErrorComponent, pass null explicitly:
 
-* `LoadingComponent={null}`
-* `ErrorComponent={null}`
+- `LoadingComponent={null}`
+- `ErrorComponent={null}`
 
 For more information about including React components in Angular, see [https://www.packtpub.com/books/content/integrating-angular-2-react](https://www.packtpub.com/books/content/integrating-angular-2-react).


### PR DESCRIPTION
Updated versions of dependencies and note mentioning the need to add a snippet to `polyfills.ts` file in order to run the application. Tested and updated back to v6.3.0 as we support two last major versions.