### PR TITLE
RELATED: RAIL-1701 add a page from 7.1.0 to next

### DIFF
--- a/docs/ht_create_your_first_visualization_toolkit.md
+++ b/docs/ht_create_your_first_visualization_toolkit.md
@@ -1,0 +1,21 @@
+---
+title: Create Your First Application Using UI Developer Toolkit
+sidebar_label: Create Your First Application Using UI Developer Toolkit
+copyright: (C) 2007-2019 GoodData Corporation
+id: ht_create_your_first_visualization_toolkit
+---
+
+Create your first analytical application using GoodData **`create-gooddata-react-app`** and **Accelerator Toolkit**.
+
+`create-gooddata-react-app` is a CLI-based tool that will guide you through the process of creating the application step by step in your terminal application.
+
+This is what is going to happen when you run `create-gooddata-react-app`:
+
+1. `create-gooddata-react-app` will download its packages and files to your computer.
+2. When completed, it will ask you to select your domain from the list or let you enter your domain name manually.
+3. Once you confirm your domain, the tool will install required dependencies and create the structure of your application.
+4. It will then prompt you to start your application and will open the welcome page in your browser. The welcome page refer you to Accelerator Toolkit, which will allow you to set up your home dashboard with a test widget.
+
+To start, go to https://github.com/gooddata/gooddata-create-gooddata-react-app, and follow the instructions in the README file.
+
+**NOTE:** You must have a GoodData account (see [About GoodData.UI](about_gooddataui.md#supported-technologies)).


### PR DESCRIPTION
The ht_create_your_first_visualization_toolkit page was missing
in the "next" version. It is an exact copy of the 7.1.0 version.