### PR TITLE
TRIVIAL: Fix project name to allow site deploy

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -20,7 +20,7 @@ const siteConfig = {
   tagline: 'A powerful JavaScript library for building analytical applications',
   url: 'https://gooddata.github.io' /* your website url */,
   baseUrl: '/gooddata-ui/' /* base url for your project */,
-  projectName: 'GoodData UI SDK',
+  projectName: 'gooddata-ui',
   headerLinks: [
     {href: '/gooddata-ui/', label: 'GoodData.UI'},
     {href: 'https://developer.gooddata.com/data-integration', label: 'Data Integration'},


### PR DESCRIPTION
Originally, there was projectName property specified twice in the siteConfig.js. Once as "GoodData UI SDK" and then overridden to "gooddata-ui". I removed the second occurrence in commit 6f16b060ff90bdef4a1dd669ca6e8d01e5e513a2 and left there "GoodData UI SDK". Unfortunately, it broke documentation publishing as project name must not have space in it as I just found out. I restored the originally used value to fix the issue.