### PR TITLE
RELATED: RAIL-2707 fix Pivot examples

### DIFF
--- a/docs/10_vis__area_chart_component.md
+++ b/docs/10_vis__area_chart_component.md
@@ -22,7 +22,6 @@ import { AreaChart } from '@gooddata/sdk-ui-charts';
 <AreaChart
     measures={<measures>}
     config={<chart-config>}
-    sdk={<sdk>}
     …
 />
 ```

--- a/docs/10_vis__insight_view.md
+++ b/docs/10_vis__insight_view.md
@@ -29,7 +29,6 @@ import { InsightView } from '@gooddata/sdk-ui-ext';
     <InsightView
         uri="<visualization-uri>"
         config={<chart-config>}
-        sdk={<sdk>}
     />
 </div>
 ```

--- a/docs/10_vis__pivot_table_component.md
+++ b/docs/10_vis__pivot_table_component.md
@@ -23,6 +23,8 @@ import { PivotTable } from '@gooddata/sdk-ui-pivot';
 
 <PivotTable
     measures={<measures>}
+    rows={<rows>}
+    columns={<columns>}
     …
 />
 ```
@@ -75,11 +77,16 @@ You can [sort](50_custom__result.md#sorting) rows and attribute columns in any p
 ```jsx
 import '@gooddata/sdk-ui-pivot/styles/css/main.css';
 import { PivotTable } from '@gooddata/sdk-ui-pivot';
-import { newMeasureSort } from "@gooddata/sdk-model";
+import { newMeasureSort, newAttributeLocator } from "@gooddata/sdk-model";
 import { Ldm } from "./ldm";
+import { monthDateIdentifierJanuary } from "./ldm/ext";
 
 const sortBy = [
-    newMeasureSort(Ldm.$FranchiseFees, "desc", newAttributeLocator(Ldm.DateMonth.Short, monthDateIdentifierJanuary))
+    newMeasureSort(
+        Ldm.$FranchiseFees,
+        "desc",
+        [newAttributeLocator(Ldm.DateMonth.Short, monthDateIdentifierJanuary)]
+    )
 ];
 
 <div style={{ height: 300 }}>
@@ -152,10 +159,10 @@ You can create these items using the following factory functions:
 -  `newWidthForAllColumnsForMeasure` sets the width of all columns for a particular measure.
 -  `newWidthForSelectedColumns` sets the width for one or more columns specified by the locators.
 
-The factory functions are exported from the `@gooddata/sdk-ui-pivot` package. 
+The factory functions are exported from the `@gooddata/sdk-ui-pivot` package.
 
 ```jsx
-const config = { 
+const config = {
     columnSizing: {
        columnWidths: [
             newWidthForAttributeColumn(Ldm.Date, 100),
@@ -187,7 +194,7 @@ const config = {
     A change of the column width calls the provided callback function with all the current column width definitions as a parameter.
 * To set the same width for all measure columns, use the width item created by the `newWidthForAllMeasureColumns` function:
     ```jsx
-    const config = { 
+    const config = {
       columnSizing: {
         columnWidths: [
             newWidthForAllMeasureColumns(200)


### PR DESCRIPTION
The rows and columns were added to the first example to trick
the syntax higlighter to not highlight the example
(same as other visualizations).

Also, removed two obsolete sdk={<sdk>} examples.