### PR TITLE
RELATED: RAIL-2719, RAIL-1815 fix formatting, unify quotes

### DIFF
--- a/docs/01_intro__platform_intro.md
+++ b/docs/01_intro__platform_intro.md
@@ -37,4 +37,4 @@ In the column chart:
 
 * `$ Avg Daily Total Sales` is a **measure**.
 * `Location State` is an **attribute**.
-* A **filter** apllied to the chart shows only USA-specific values of `Location State`, which represent the offices located in the USA.
+* A **filter** applied to the chart shows only USA-specific values of `Location State`, which represent the offices located in the USA.

--- a/docs/02_start__catalog_export.md
+++ b/docs/02_start__catalog_export.md
@@ -46,11 +46,11 @@ This is how it works:
 
     ```json
     {
-     "hostname": "your.gooddata.hostname.com",
-     "projectId": "your_gooddata_workspaceid",
-     "username": "email",
-     "password": "password",
-     "output": "desired_file_name.ts|js|json"
+        "hostname": "your.gooddata.hostname.com",
+        "projectId": "your_gooddata_workspaceid",
+        "username": "email",
+        "password": "password",
+        "output": "desired_file_name.ts|js|json"
     }
     ```
 

--- a/docs/02_start__connecting_backend.md
+++ b/docs/02_start__connecting_backend.md
@@ -38,7 +38,7 @@ The following procedure implements the initial setup using the providers to pass
 
     ```jsx
     <BackendProvider backend={backend}>
-        <WorkspaceProvider workspace='your-project-id'>
+        <WorkspaceProvider workspace="your-project-id">
             <YourApplicationTree />
         </WorkspaceProvider>
     </BackendProvider>

--- a/docs/02_start__execution_model.md
+++ b/docs/02_start__execution_model.md
@@ -8,7 +8,7 @@ copyright: (C) 2018-2019 GoodData Corporation
 The GoodData.UI execution model allows you to easily create different **data specification** inputs for the
 visualization components.
 
-The execution model and other smaller models are implemented in the `@gooddata/sdk-model` package. 
+The execution model and other smaller models are implemented in the `@gooddata/sdk-model` package.
 
 While you can create different inputs without the model functions, we strongly recommend using the functionality
 of the execution model, especially in conjunction with the [catalog-export](02_start__catalog_export.md) tool.
@@ -22,7 +22,7 @@ of GoodData.UI and the applications we build using the framework.
 ## Execution model concepts
 
 To simplify the creation of various types of objects that specify what data to render, the model uses a combination
-of two typical object creation patterns: factory function and builder. 
+of two typical object creation patterns: factory function and builder.
 
 ### Creating objects
 
@@ -56,8 +56,8 @@ are several conventions:
 
 ### Local identifiers and referencing objects
 
-The `localIdentifier`, or `localId` for short, is a user-assigned identifier that you have to use when referencing 
-attributes and measures in the scope of a single visualization or execution. 
+The `localIdentifier`, or `localId` for short, is a user-assigned identifier that you have to use when referencing
+attributes and measures in the scope of a single visualization or execution.
 
 The execution model automatically generates stable `localId`'s as it creates the attribute and measure objects. You can pass the attribute and measure objects by its value. However, if you want to use the same attribute or measure multiple times in the same visualization, you have to create a copy of the object and assign it a different `localId` yourself.
 
@@ -65,7 +65,7 @@ You can use the `modify<ObjectType>` functions to override the `localId` of an a
 
 -  If you call the `m => m.defaultLocalId()`, the default logic for `localId` generation will kick in **after** all
    other object modifications are applied.
-   
+
 -  If you call the `m => m.localId(customValue)`, the modified object will have your custom `localId`.
 
 -  If you do not call `defaultLocalId` or `localId`, the modification object will have the same `localId` as the
@@ -77,13 +77,13 @@ The factory function that creates an attribute is `newAttribute`, and the modifi
 usage is straightforward:
 
 ```javascript
-import { newAttribute, modifyAttribute } from '@gooddata/sdk-model';
+import { newAttribute, modifyAttribute } from "@gooddata/sdk-model";
 
 const attribute = newAttribute("displayFormIdentifier", m => m.alias("My Custom Name"));
 
 // notice the call to defaultLocalId() - this ensures the new object will have a different, generated localId
 const sameAttributeDifferentName = modifyAttribute(attribute, m => m.alias("Corrected Name").defaultLocalId());
-``` 
+```
 
 ## Measures
 
@@ -99,21 +99,21 @@ The modification function is `modifyMeasure`. It modifies measure-agnostic param
 **Example:**
 
 ```js harmony
-import { newMeasure, newArithmeticMeasure, modifyMeasure } from '@gooddata/sdk-model';
+import { newMeasure, newArithmeticMeasure, modifyMeasure } from "@gooddata/sdk-model";
 
-const measureFromMaqlMetric = newMeasure('maqlMetricIdentifier');
-const measureFromFact = newMeasure('factIdentifier', m => m.aggregation("avg").alias("Custom Name"));
-const measureWithFilter = newMeasure('factIdentifier', m => m.filters(newPositiveAttributeFilter('displayFormId', ['value'])));
+const measureFromMaqlMetric = newMeasure("maqlMetricIdentifier");
+const measureFromFact = newMeasure("factIdentifier", m => m.aggregation("avg").alias("Custom Name"));
+const measureWithFilter = newMeasure("factIdentifier", m => m.filters(newPositiveAttributeFilter("displayFormId", ["value"])));
 
 const arithmeticMeasure = newArithmeticMeasure(
-                                [measureFromFact, measureFromMaqlMetric], 
-                                "sum", 
+                                [measureFromFact, measureFromMaqlMetric],
+                                "sum",
                                 m => m.alias("Custom Name For Arithmetic Measure").format("$#,#0.0")
                           );
 
 // notice the call to defaultLocalId; this ensures that this new measure will have a different localId - one that reflects
 // that the title and the format is different.
-const modifiedArithmeticMeasure = modifyMeasure(arithmeticMeasure, 
+const modifiedArithmeticMeasure = modifyMeasure(arithmeticMeasure,
                                     m => m.alias("Different Name For Arithmetic Measure").format("$#,#0").defaultLocalId()
                                   );
 ```
@@ -139,7 +139,7 @@ The execution model provides factory functions to create sort items and the resp
 - `newAttributeSortItem` creates a new attribute sort item.
 - `newMeasureSortItem` creates a new measure value sort item.
 
-For both of these, you can specify an attribute or measure either by `localId` or by passing the actual object. 
+For both of these, you can specify an attribute or measure either by `localId` or by passing the actual object.
 
 The second parameter is always the sort direction.
 
@@ -148,21 +148,21 @@ When sorting by measures that are scoped for a particular attribute value (for e
 **Example:**
 
 ```js harmony
-import { newAttribute, newMeasure, newAttributeSort, newMeasureSort, newAttributeLocator } from '@gooddata/sdk-model';
+import { newAttribute, newMeasure, newAttributeSort, newMeasureSort, newAttributeLocator } from "@gooddata/sdk-model";
 
-const attribute = newAttribute('displayFormIdentifier', m => m.alias("Custom Dimension"));
-const measure = newMeasure('maqlMetricIdentifier', m => m.alias("My Measure").format("#0"));
+const attribute = newAttribute("displayFormIdentifier", m => m.alias("Custom Dimension"));
+const measure = newMeasure("maqlMetricIdentifier", m => m.alias("My Measure").format("#0"));
 
 const attributeSort = newAttributeSort(attribute, "asc");
 
-const measureSortWithoutAttributeLocator = newMeasureSort(measure, "asc"); 
+const measureSortWithoutAttributeLocator = newMeasureSort(measure, "asc");
 const measureSortWithAttributeLocator = newMeasureSort(measure, "asc", [newAttributeLocator(attribute, "element-uri")])
 ```
 
 ### Attribute area sorting
 
-You can specify that the attribute sort should sort attribute values based on an aggregation function applied to 
-all valid values belonging to each attribute value. This is extremely useful when sorting stacked visualizations such 
+You can specify that the attribute sort should sort attribute values based on an aggregation function applied to
+all valid values belonging to each attribute value. This is extremely useful when sorting stacked visualizations such
 as stacked bar charts or area charts.
 
 Currently, only sorting by the `sum` function is supported.
@@ -170,9 +170,9 @@ Currently, only sorting by the `sum` function is supported.
 The following example shows sorting a table with two measures and a `Year` attribute. You can set sorting based on the `Year` attribute with:
 
 ```javascript
-import { newAttribute, newAttributeAreaSort } from '@gooddata/sdk-model';
+import { newAttribute, newAttributeAreaSort } from "@gooddata/sdk-model";
 
-const attribute = newAttribute('displayFormIdentifier', m => m.alias("Custom Dimension"));
+const attribute = newAttribute("displayFormIdentifier", m => m.alias("Custom Dimension"));
 
 newAttributeAreaSort(attribute, "asc")
 ```
@@ -184,7 +184,7 @@ Consider the following original data:
 | Measures | M1 | M2 | M1 | M2 |
 | Values | 1 | 2 | 3 | 4 |
 
-The sorting function (`sum`) is applied to all attribute element values for each attribute element (`2006` and `2007`). 
+The sorting function (`sum`) is applied to all attribute element values for each attribute element (`2006` and `2007`).
 Notice that the area sort is summing up values across different measures (M1 and M2):
 
 | 2006 | 2007 |

--- a/docs/02_start__no_boilerplate.md
+++ b/docs/02_start__no_boilerplate.md
@@ -54,7 +54,7 @@ This command adds the necessary GoodData.UI packages to the list of your project
 **Before** you start your development server, prevent cross-origin issues by [adding proxy settings](30_tips__cors.md). To set up a proxy, in your project's `/src` directory, create the `setupProxy.js` file with the following content:
 
 ```javascript
-const proxy = require('http-proxy-middleware');
+const proxy = require("http-proxy-middleware");
 
 module.exports = function (app) {
      app.use(proxy("/gdc", {
@@ -67,7 +67,7 @@ module.exports = function (app) {
              "origin": null
          },
          "onProxyReq": function(proxyReq, req, res) {
-             proxyReq.setHeader('accept-encoding', 'identity')
+             proxyReq.setHeader("accept-encoding", "identity")
          }
      }));
      app.use(proxy("/*.html", {
@@ -127,13 +127,13 @@ Now, you can start adding your first GoodData component:
 1. Open `src/App.js` in a text editor.
 2. Add the following line to the other `import`s at the beginning of the `App.js` file:
     ```javascript
-    import { LineChart } from '@gooddata/sdk-ui-charts';
-    import { newMeasure, newAttribute } from '@gooddata/sdk-model';
-    import bearFactory, {ContextDeferredAuthProvider} from '@gooddata/sdk-backend-bear';
+    import { LineChart } from "@gooddata/sdk-ui-charts";
+    import { newMeasure, newAttribute } from "@gooddata/sdk-model";
+    import bearFactory, {ContextDeferredAuthProvider} from "@gooddata/sdk-backend-bear";
     ```
 3. Add the following line to the other `import`s at the beginning of the `App.js` file to load CSS:
     ```javascript
-    import '@gooddata/sdk-ui-charts/styles/css/main.css';
+    import "@gooddata/sdk-ui-charts/styles/css/main.css";
     ```
 
 4. Initialize the Analytical Backend implemented by the GoodData platform:
@@ -150,7 +150,7 @@ Now, you can start adding your first GoodData component:
    function App() {
        return (
            <BackendProvider backend={backend}>
-               <WorkspaceProvider workspace='xms7ga4tf3g3nzucd8380o2bev8oeknp'>
+               <WorkspaceProvider workspace="xms7ga4tf3g3nzucd8380o2bev8oeknp">
                    <div>placeholder</div>
                </WorkspaceProvider>
            </BackendProvider>
@@ -162,8 +162,8 @@ Now, you can start adding your first GoodData component:
 
     6a. Define measures and attributes:
     ```javascript
-    const measures = [ newMeasure('aaEGaXAEgB7U', m => m.format('#,##0') ];
-    const attribute = newAttribute('date.abm81lMifn6q');
+    const measures = [ newMeasure("aaEGaXAEgB7U", m => m.format("#,##0") ];
+    const attribute = newAttribute("date.abm81lMifn6q");
     ```
 
     6b. Replace the placeholder in your `App` functional component with the following elements:
@@ -173,7 +173,7 @@ Now, you can start adding your first GoodData component:
           measures={measures}
           trendBy={attribute}
           config={{
-              colors: ['#14b2e2']
+              colors: ["#14b2e2"]
           }}
       />
     </div>
@@ -183,27 +183,27 @@ Now, you can start adding your first GoodData component:
 7. Save the changes. The content of your `App.js` file should now look something like the following example:
 
     ```jsx
-    import React from 'react';
-    import { newMeasure, newAttribute } from '@gooddata/sdk-model';
-    import bearFactory from '@gooddata/sdk-backend-bear';
-    import '@gooddata/sdk-ui-charts/styles/css/main.css';
+    import React from "react";
+    import { newMeasure, newAttribute } from "@gooddata/sdk-model";
+    import bearFactory from "@gooddata/sdk-backend-bear";
+    import "@gooddata/sdk-ui-charts/styles/css/main.css";
 
-    import './App.css';
+    import "./App.css";
 
     const backend = bearFactory().withAuthentication(new ContextDeferredAuthProvider());
-    const measures = [ newMeasure('aaEGaXAEgB7U', m => m.format('#,##0') ];
-    const attribute = newAttribute('date.abm81lMifn6q');
+    const measures = [ newMeasure("aaEGaXAEgB7U", m => m.format("#,##0") ];
+    const attribute = newAttribute("date.abm81lMifn6q");
 
     function App() {
         return (
             <BackendProvider backend={backend}>
-               <WorkspaceProvider workspace='xms7ga4tf3g3nzucd8380o2bev8oeknp'>
+               <WorkspaceProvider workspace="xms7ga4tf3g3nzucd8380o2bev8oeknp">
                     <div style={{ height: 300 }}>
                         <LineChart
                             measures={measures}
                             trendBy={attribute}
                             config={{
-                                colors: ['#14b2e2']
+                                colors: ["#14b2e2"]
                             }}
                         />
                     </div>

--- a/docs/10_vis__area_chart_component.md
+++ b/docs/10_vis__area_chart_component.md
@@ -16,8 +16,8 @@ Areas stack by default. Alternatively, the areas can overlap if ```{ stackMeasur
 ## Structure
 
 ```jsx
-import '@gooddata/sdk-ui-charts/styles/css/main.css';
-import { AreaChart } from '@gooddata/sdk-ui-charts';
+import "@gooddata/sdk-ui-charts/styles/css/main.css";
+import { AreaChart } from "@gooddata/sdk-ui-charts";
 
 <AreaChart
     measures={<measures>}
@@ -29,8 +29,8 @@ import { AreaChart } from '@gooddata/sdk-ui-charts';
 ## Example
 
 ```jsx
-import '@gooddata/sdk-ui-charts/styles/css/main.css';
-import { AreaChart } from '@gooddata/sdk-ui-charts';
+import "@gooddata/sdk-ui-charts/styles/css/main.css";
+import { AreaChart } from "@gooddata/sdk-ui-charts";
 import {Ldm} from "./ldm";
 
 const style = { height: 300 };
@@ -64,16 +64,16 @@ const style = { height: 300 };
 The following example shows the supported `config` structure with sample values. For the descriptions of the individual options, see [ChartConfig](15_props__chart_config.md).
 ```javascript
 {
-    colors: ['rgb(195, 49, 73)', 'rgb(168, 194, 86)'],
+    colors: ["rgb(195, 49, 73)", "rgb(168, 194, 86)"],
     colorPalette: [{
-        guid: '01',
+        guid: "01",
         fill: {
             r: 195,
             g: 49,
             b: 73
         }
     }, {
-        guid: '02',
+        guid: "02",
         fill: {
             r: 168,
             g: 194,
@@ -82,38 +82,38 @@ The following example shows the supported `config` structure with sample values.
     }],
     colorMapping: [{
         predicate: (headerItem) => {
-            return headerItem.measureHeaderItem && (headerItem.measureHeaderItem.localIdentifier === 'm1_localIdentifier')
+            return headerItem.measureHeaderItem && (headerItem.measureHeaderItem.localIdentifier === "m1_localIdentifier")
         },
         color: {
-            type: 'guid',
-            value: '02'
+            type: "guid",
+            value: "02"
         }
     }],
     xaxis: {
         visible: true,
         labelsEnabled: true,
-        rotation: 'auto'
+        rotation: "auto"
     },
     yaxis: {
         visible: true,
         labelsEnabled: true,
-        rotation: 'auto',
-        min: '20',
-        max: '30'
+        rotation: "auto",
+        min: "20",
+        max: "30"
     },
     legend: {
         enabled: true,
-        position: 'top',
+        position: "top",
     },
     dataLabels: {
-        visible: 'auto'
+        visible: "auto"
     },
     grid: {
         enabled: true
     }
     separators: {
-        thousand: ',',
-        decimal: '.'
+        thousand: ",",
+        decimal: "."
     }
 }
 ```

--- a/docs/10_vis__attribute_filter_component.md
+++ b/docs/10_vis__attribute_filter_component.md
@@ -17,18 +17,18 @@ In the following example, attribute values are listed and the ```onApply``` call
 The `onApply` callback receives a new filter definition that you can use to filter charts.
 
 ```jsx
-import React, { Component } from 'react';
-import { AttributeFilter, Model } from '@gooddata/sdk-ui-filters';
-import { newNegativeAttributeFilter } from '@gooddata/sdk-model';
+import React, { Component } from "react";
+import { AttributeFilter, Model } from "@gooddata/sdk-ui-filters";
+import { newNegativeAttributeFilter } from "@gooddata/sdk-model";
 
-import '@gooddata/sdk-ui-filters/styles/css/main.css';
+import "@gooddata/sdk-ui-filters/styles/css/main.css";
 
 import { Ldm } from "./ldm";
 
 export class AttributeFilterExample extends Component {
     onApply(filter) {
         // eslint-disable-next-line no-console
-        console.log('AttributeFilterExample onApply', filter);
+        console.log("AttributeFilterExample onApply", filter);
     }
 
     render() {

--- a/docs/10_vis__bar_chart_component.md
+++ b/docs/10_vis__bar_chart_component.md
@@ -12,8 +12,8 @@ A **bar chart** shows data in horizontal bars. Bar charts can display one or mul
 ## Structure
 
 ```jsx
-import '@gooddata/sdk-ui-charts/styles/css/main.css';
-import { BarChart } from '@gooddata/sdk-ui-charts';
+import "@gooddata/sdk-ui-charts/styles/css/main.css";
+import { BarChart } from "@gooddata/sdk-ui-charts";
 
 <BarChart
     measures={<measures>}
@@ -25,8 +25,8 @@ import { BarChart } from '@gooddata/sdk-ui-charts';
 ## Example
 
 ```jsx
-import '@gooddata/sdk-ui-charts/styles/css/main.css';
-import { BarChart } from '@gooddata/sdk-ui-charts';
+import "@gooddata/sdk-ui-charts/styles/css/main.css";
+import { BarChart } from "@gooddata/sdk-ui-charts";
 import { Ldm } from "./ldm";
 
 const style = { height: 300 };
@@ -62,16 +62,16 @@ The following example shows the supported `config` structure with sample values.
 
 ```javascript
 {
-    colors: ['rgb(195, 49, 73)', 'rgb(168, 194, 86)'],
+    colors: ["rgb(195, 49, 73)", "rgb(168, 194, 86)"],
     colorPalette: [{
-        guid: '01',
+        guid: "01",
         fill: {
             r: 195,
             g: 49,
             b: 73
         }
     }, {
-        guid: '02',
+        guid: "02",
         fill: {
             r: 168,
             g: 194,
@@ -80,38 +80,38 @@ The following example shows the supported `config` structure with sample values.
     }],
     colorMapping: [{
         predicate: (headerItem) => {
-            return headerItem.measureHeaderItem && (headerItem.measureHeaderItem.localIdentifier === 'm1_localIdentifier')
+            return headerItem.measureHeaderItem && (headerItem.measureHeaderItem.localIdentifier === "m1_localIdentifier")
         },
         color: {
-            type: 'guid',
-            value: '02'
+            type: "guid",
+            value: "02"
         }
     }],
     xaxis: {
         visible: true,
         labelsEnabled: true,
-        rotation: 'auto',
-        min: '20',
-        max: '30'
+        rotation: "auto",
+        min: "20",
+        max: "30"
     },
     yaxis: {
         visible: true,
         labelsEnabled: true,
-        rotation: 'auto'
+        rotation: "auto"
     },
     legend: {
         enabled: true,
-        position: 'top',
+        position: "top",
     },
     dataLabels: {
-        visible: 'auto'
+        visible: "auto"
     },
     grid: {
         enabled: true
     }
     separators: {
-        thousand: ',',
-        decimal: '.'
+        thousand: ",",
+        decimal: "."
     }
 }
 ```

--- a/docs/10_vis__bubble_chart_component.md
+++ b/docs/10_vis__bubble_chart_component.md
@@ -14,8 +14,8 @@ The data is sliced by an attribute, with each bubble (an attribute item) noted w
 ## Structure
 
 ```jsx
-import '@gooddata/sdk-ui-charts/styles/css/main.css';
-import { BubbleChart } from '@gooddata/sdk-ui-charts';
+import "@gooddata/sdk-ui-charts/styles/css/main.css";
+import { BubbleChart } from "@gooddata/sdk-ui-charts";
 
 <BubbleChart
     xAxisMeasure={<measure>}
@@ -30,8 +30,8 @@ import { BubbleChart } from '@gooddata/sdk-ui-charts';
 ## Example
 
 ```jsx
-import '@gooddata/sdk-ui-charts/styles/css/main.css';
-import { BubbleChart } from '@gooddata/sdk-ui-charts';
+import "@gooddata/sdk-ui-charts/styles/css/main.css";
+import { BubbleChart } from "@gooddata/sdk-ui-charts";
 
 import { Ldm } from "./ldm";
 
@@ -70,16 +70,16 @@ The following example shows the supported `config` structure with sample values.
 
 ```javascript
 {
-    colors: ['rgb(195, 49, 73)', 'rgb(168, 194, 86)'],
+    colors: ["rgb(195, 49, 73)", "rgb(168, 194, 86)"],
     colorPalette: [{
-        guid: '01',
+        guid: "01",
         fill: {
             r: 195,
             g: 49,
             b: 73
         }
     }, {
-        guid: '02',
+        guid: "02",
         fill: {
             r: 168,
             g: 194,
@@ -88,40 +88,40 @@ The following example shows the supported `config` structure with sample values.
     }],
     colorMapping: [{
         predicate: (headerItem) => {
-            return headerItem.measureHeaderItem && (headerItem.measureHeaderItem.localIdentifier === 'm1_localIdentifier')
+            return headerItem.measureHeaderItem && (headerItem.measureHeaderItem.localIdentifier === "m1_localIdentifier")
         },
         color: {
-            type: 'guid',
-            value: '02'
+            type: "guid",
+            value: "02"
         }
     }],
     xaxis: {
         visible: true,
         labelsEnabled: true,
-        rotation: 'auto',
-        min: '20',
-        max: '30'
+        rotation: "auto",
+        min: "20",
+        max: "30"
     },
     yaxis: {
         visible: true,
         labelsEnabled: true,
-        rotation: 'auto',
-        min: '20',
-        max: '30'
+        rotation: "auto",
+        min: "20",
+        max: "30"
     },
     legend: {
         enabled: true,
-        position: 'right',
+        position: "right",
     },
     dataLabels: {
-        visible: 'auto'
+        visible: "auto"
     },
     grid: {
         enabled: true
     }
     separators: {
-        thousand: ',',
-        decimal: '.'
+        thousand: ",",
+        decimal: "."
     }
 }
 ```

--- a/docs/10_vis__bullet_chart_component.md
+++ b/docs/10_vis__bullet_chart_component.md
@@ -12,8 +12,8 @@ A **bullet chart** is a variation of a bar chart that displays performance of a 
 ## Structure
 
 ```jsx
-import '@gooddata/sdk-ui-charts/styles/css/main.css';
-import { BulletChart } from '@gooddata/sdk-ui-charts';
+import "@gooddata/sdk-ui-charts/styles/css/main.css";
+import { BulletChart } from "@gooddata/sdk-ui-charts";
 
 <BulletChart
     primaryMeasure={<primaryMeasure>}
@@ -27,8 +27,8 @@ import { BulletChart } from '@gooddata/sdk-ui-charts';
 ## Example
 
 ```jsx
-import '@gooddata/sdk-ui-charts/styles/css/main.css';
-import { BulletChart } from '@gooddata/sdk-ui-charts';
+import "@gooddata/sdk-ui-charts/styles/css/main.css";
+import { BulletChart } from "@gooddata/sdk-ui-charts";
 import { Ldm } from "./ldm";
 
 const style = { height: 300 };
@@ -75,9 +75,9 @@ The following example shows the supported `config` structure with sample values.
 
 ```javascript
 {
-    colors: ['rgb(195, 49, 73)'],
+    colors: ["rgb(195, 49, 73)"],
     colorPalette: [{
-        guid: '01',
+        guid: "01",
         fill: {
             r: 195,
             g: 49,
@@ -86,38 +86,38 @@ The following example shows the supported `config` structure with sample values.
     }],
     colorMapping: [{
         predicate: (headerItem) => {
-            return headerItem.measureHeaderItem && (headerItem.measureHeaderItem.localIdentifier === 'm1_localIdentifier')
+            return headerItem.measureHeaderItem && (headerItem.measureHeaderItem.localIdentifier === "m1_localIdentifier")
         },
         color: {
-            type: 'guid',
-            value: '01'
+            type: "guid",
+            value: "01"
         }
     }],
     xaxis: {
         visible: true,
         labelsEnabled: true,
-        rotation: 'auto'
+        rotation: "auto"
     },
     yaxis: {
         visible: true,
         labelsEnabled: true,
-        rotation: 'auto',
-        min: '20',
-        max: '30'
+        rotation: "auto",
+        min: "20",
+        max: "30"
     },
     legend: {
         enabled: true,
-        position: 'top',
+        position: "top",
     },
     dataLabels: {
-        visible: 'auto'
+        visible: "auto"
     },
     grid: {
         enabled: true
     }
     separators: {
-        thousand: ',',
-        decimal: '.'
+        thousand: ",",
+        decimal: "."
     }
 }
 ```

--- a/docs/10_vis__column_chart_component.md
+++ b/docs/10_vis__column_chart_component.md
@@ -12,8 +12,8 @@ A **column chart** shows data in vertical columns. Column charts can display one
 ## Structure
 
 ```jsx
-import '@gooddata/sdk-ui-charts/styles/css/main.css';
-import { ColumnChart } from '@gooddata/sdk-ui-charts';
+import "@gooddata/sdk-ui-charts/styles/css/main.css";
+import { ColumnChart } from "@gooddata/sdk-ui-charts";
 
 <ColumnChart
     measures={<measures>}
@@ -25,8 +25,8 @@ import { ColumnChart } from '@gooddata/sdk-ui-charts';
 ## Example
 
 ```jsx
-import '@gooddata/sdk-ui-charts/styles/css/main.css';
-import { ColumnChart } from '@gooddata/sdk-ui-charts';
+import "@gooddata/sdk-ui-charts/styles/css/main.css";
+import { ColumnChart } from "@gooddata/sdk-ui-charts";
 import { Ldm } from "./ldm";
 
 const style = { height: 300 };
@@ -61,16 +61,16 @@ The following example shows the supported `config` structure with sample values.
 
 ```javascript
 {
-    colors: ['rgb(195, 49, 73)', 'rgb(168, 194, 86)'],
+    colors: ["rgb(195, 49, 73)", "rgb(168, 194, 86)"],
     colorPalette: [{
-        guid: '01',
+        guid: "01",
         fill: {
             r: 195,
             g: 49,
             b: 73
         }
     }, {
-        guid: '02',
+        guid: "02",
         fill: {
             r: 168,
             g: 194,
@@ -79,38 +79,38 @@ The following example shows the supported `config` structure with sample values.
     }],
     colorMapping: [{
         predicate: (headerItem) => {
-            return headerItem.measureHeaderItem && (headerItem.measureHeaderItem.localIdentifier === 'm1_localIdentifier')
+            return headerItem.measureHeaderItem && (headerItem.measureHeaderItem.localIdentifier === "m1_localIdentifier")
         },
         color: {
-            type: 'guid',
-            value: '02'
+            type: "guid",
+            value: "02"
         }
     }],
     xaxis: {
         visible: true,
         labelsEnabled: true,
-        rotation: 'auto'
+        rotation: "auto"
     },
     yaxis: {
         visible: true,
         labelsEnabled: true,
-        rotation: 'auto',
-        min: '20',
-        max: '30'
+        rotation: "auto",
+        min: "20",
+        max: "30"
     },
     legend: {
         enabled: true,
-        position: 'bottom',
+        position: "bottom",
     },
     dataLabels: {
-        visible: 'auto'
+        visible: "auto"
     },
     grid: {
         enabled: true
     }
     separators: {
-        thousand: ',',
-        decimal: '.'
+        thousand: ",",
+        decimal: "."
     }
 }
 ```

--- a/docs/10_vis__combo_chart_component.md
+++ b/docs/10_vis__combo_chart_component.md
@@ -16,8 +16,8 @@ By default, a combo chart is displayed as a combination of a column chart and a 
 ## Structure
 
 ```jsx
-import '@gooddata/sdk-ui-charts/styles/css/main.css';
-import { ComboChart } from '@gooddata/sdk-ui-charts';
+import "@gooddata/sdk-ui-charts/styles/css/main.css";
+import { ComboChart } from "@gooddata/sdk-ui-charts";
 
 <ComboChart
     primaryMeasures={<primaryMeasures>}
@@ -30,8 +30,8 @@ import { ComboChart } from '@gooddata/sdk-ui-charts';
 ## Example
 
 ```jsx
-import '@gooddata/sdk-ui-charts/styles/css/main.css';
-import { ComboChart } from '@gooddata/sdk-ui-charts';
+import "@gooddata/sdk-ui-charts/styles/css/main.css";
+import { ComboChart } from "@gooddata/sdk-ui-charts";
 import { Ldm } from "./ldm";
 
 const style = { height: 300 };
@@ -57,15 +57,15 @@ To change the chart type for primary measures, set the `config.primaryChartType`
 To change the chart type for secondary measures, set the `config.secondaryChartType` property.
 
 ```jsx
-import '@gooddata/sdk-ui-charts/styles/css/main.css';
-import { ComboChart } from '@gooddata/sdk-ui-charts';
+import "@gooddata/sdk-ui-charts/styles/css/main.css";
+import { ComboChart } from "@gooddata/sdk-ui-charts";
 
 <ComboChart
     primaryMeasures={<primaryMeasures>}
     secondaryMeasures={<secondaryMeasures>}
     config={{
-        primaryChartType: 'column', // string
-        secondaryChartType: 'area' // string
+        primaryChartType: "column", // string
+        secondaryChartType: "area" // string
     }}
     viewBy={<attribute>}
 />
@@ -76,8 +76,8 @@ import { ComboChart } from '@gooddata/sdk-ui-charts';
 To disable the secondary axis, set the `config.dualAxis` property to `false`.
 
 ```jsx
-import '@gooddata/sdk-ui-charts/styles/css/main.css';
-import { ComboChart } from '@gooddata/sdk-ui-charts';
+import "@gooddata/sdk-ui-charts/styles/css/main.css";
+import { ComboChart } from "@gooddata/sdk-ui-charts";
 
 <ComboChart
     primaryMeasures={<primaryMeasures>}
@@ -111,16 +111,16 @@ The following example shows the supported `config` structure with sample values.
 
 ```javascript
 {
-    colors: ['rgb(195, 49, 73)', 'rgb(168, 194, 86)'],
+    colors: ["rgb(195, 49, 73)", "rgb(168, 194, 86)"],
     colorPalette: [{
-        guid: '01',
+        guid: "01",
         fill: {
             r: 195,
             g: 49,
             b: 73
         }
     }, {
-        guid: '02',
+        guid: "02",
         fill: {
             r: 168,
             g: 194,
@@ -129,38 +129,38 @@ The following example shows the supported `config` structure with sample values.
     }],
     colorMapping: [{
         predicate: (headerItem) => {
-            return headerItem.measureHeaderItem && (headerItem.measureHeaderItem.localIdentifier === 'm1_localIdentifier')
+            return headerItem.measureHeaderItem && (headerItem.measureHeaderItem.localIdentifier === "m1_localIdentifier")
         },
         color: {
-            type: 'guid',
-            value: '02'
+            type: "guid",
+            value: "02"
         }
     }],
     xaxis: {
         visible: true,
         labelsEnabled: true,
-        rotation: 'auto'
+        rotation: "auto"
     },
     yaxis: {
         visible: true,
         labelsEnabled: true,
-        rotation: 'auto',
-        min: '20',
-        max: '30'
+        rotation: "auto",
+        min: "20",
+        max: "30"
     },
     legend: {
         enabled: true,
-        position: 'top',
+        position: "top",
     },
     dataLabels: {
-        visible: 'auto'
+        visible: "auto"
     },
     grid: {
         enabled: true
     }
     separators: {
-        thousand: ',',
-        decimal: '.'
+        thousand: ",",
+        decimal: "."
     }
 }
 ```

--- a/docs/10_vis__donut_chart.md
+++ b/docs/10_vis__donut_chart.md
@@ -12,8 +12,8 @@ A **donut chart** shows data as proportional segments of a disc and has a hollow
 ## Structure
 
 ```jsx
-import '@gooddata/sdk-ui-charts/styles/css/main.css';
-import { DonutChart } from '@gooddata/sdk-ui-charts';
+import "@gooddata/sdk-ui-charts/styles/css/main.css";
+import { DonutChart } from "@gooddata/sdk-ui-charts";
 
 <DonutChart
     measures={<measures>}
@@ -25,8 +25,8 @@ import { DonutChart } from '@gooddata/sdk-ui-charts';
 ## Example
 
 ```jsx
-import '@gooddata/sdk-ui-charts/styles/css/main.css';
-import { DonutChart } from '@gooddata/sdk-ui-charts';
+import "@gooddata/sdk-ui-charts/styles/css/main.css";
+import { DonutChart } from "@gooddata/sdk-ui-charts";
 
 const style = { height: 300 };
 
@@ -62,16 +62,16 @@ The following example shows the supported `config` structure with sample values.
 
 ```javascript
 {
-    colors: ['rgb(195, 49, 73)', 'rgb(168, 194, 86)'],
+    colors: ["rgb(195, 49, 73)", "rgb(168, 194, 86)"],
     colorPalette: [{
-        guid: '01',
+        guid: "01",
         fill: {
             r: 195,
             g: 49,
             b: 73
         }
     }, {
-        guid: '02',
+        guid: "02",
         fill: {
             r: 168,
             g: 194,
@@ -80,23 +80,23 @@ The following example shows the supported `config` structure with sample values.
     }],
     colorMapping: [{
         predicate: (headerItem) => {
-            return headerItem.measureHeaderItem && (headerItem.measureHeaderItem.localIdentifier === 'm1_localIdentifier')
+            return headerItem.measureHeaderItem && (headerItem.measureHeaderItem.localIdentifier === "m1_localIdentifier")
         },
         color: {
-            type: 'guid',
-            value: '02'
+            type: "guid",
+            value: "02"
         }
     }],
     legend: {
         enabled: true,
-        position: 'top',
+        position: "top",
     },
     dataLabels: {
-        visible: 'auto'
+        visible: "auto"
     },
     separators: {
-        thousand: ',',
-        decimal: '.'
+        thousand: ",",
+        decimal: "."
     }
 }
 ```

--- a/docs/10_vis__geo_pushpin_chart_component.md
+++ b/docs/10_vis__geo_pushpin_chart_component.md
@@ -12,8 +12,8 @@ A **geo pushpin chart** visualizes data broken down by geographic region across 
 ## Structure
 
 ```jsx
-import '@gooddata/sdk-ui-geo/styles/css/main.css';
-import { GeoPushpinChart } from '@gooddata/sdk-ui-geo';
+import "@gooddata/sdk-ui-geo/styles/css/main.css";
+import { GeoPushpinChart } from "@gooddata/sdk-ui-geo";
 
 <GeoPushpinChart
     location={<attribute>}
@@ -28,12 +28,12 @@ import { GeoPushpinChart } from '@gooddata/sdk-ui-geo';
 ## Example
 
 ```jsx
-import '@gooddata/sdk-ui-geo/styles/css/main.css';
-import { GeoPushpinChart } from '@gooddata/sdk-ui-geo';
+import "@gooddata/sdk-ui-geo/styles/css/main.css";
+import { GeoPushpinChart } from "@gooddata/sdk-ui-geo";
 import { Ldm } from "./ldm";
 
 const config = {
-    mapboxToken: 'your_mapbox_token',
+    mapboxToken: "your_mapbox_token",
     tooltipText: Ldm.City.Name
 };
 
@@ -80,39 +80,39 @@ The following example shows the supported `geoConfig` structure with sample valu
 ```javascript
 {
     points: {
-        minSize: '0.5x', // '0.5x' | '0.75x' | 'normal' | '1.25x' | '1.5x'  
-        maxSize: '1.5x', // '0.5x' | '0.75x' | 'normal' | '1.25x' | '1.5x'
+        minSize: "0.5x", // "0.5x" | "0.75x" | "normal" | "1.25x" | "1.5x"
+        maxSize: "1.5x", // "0.5x" | "0.75x" | "normal" | "1.25x" | "1.5x"
         groupNearbyPoints: true
     },
     viewport: {
-        // 'auto' // default, Include all data
-        // 'continent_af' // Africa
-        // 'continent_as' // Asia
-        // 'continent_au' // Australia
-        // 'continent_eu' // Europe
-        // 'continent_na' // North America
-        // 'continent_sa' // South America
+        // "auto" // default, Include all data
+        // "continent_af" // Africa
+        // "continent_as" // Asia
+        // "continent_au" // Australia
+        // "continent_eu" // Europe
+        // "continent_na" // North America
+        // "continent_sa" // South America
         // "world";
-        area: 'world',
+        area: "world",
     },
     tooltipText: {
         visualizationAttribute: {
             displayForm: {
                 identifier: usStateNameIdentifier
             },
-            localIdentifier: 'usStateNameIdentifier'
+            localIdentifier: "usStateNameIdentifier"
         }
     },
-    colors: ['rgb(195, 49, 73)', 'rgb(168, 194, 86)'],
+    colors: ["rgb(195, 49, 73)", "rgb(168, 194, 86)"],
     colorPalette: [{
-        guid: '01',
+        guid: "01",
         fill: {
             r: 195,
             g: 49,
             b: 73
         }
     }, {
-        guid: '02',
+        guid: "02",
         fill: {
             r: 168,
             g: 194,
@@ -121,20 +121,20 @@ The following example shows the supported `geoConfig` structure with sample valu
     }],
     colorMapping: [{
         predicate: (headerItem) => {
-            return headerItem.attributeHeaderItem && (headerItem.attributeHeaderItem.name === 'adult'); // age
+            return headerItem.attributeHeaderItem && (headerItem.attributeHeaderItem.name === "adult"); // age
         },
         color: {
-            type: 'guid',
-            value: '02'
+            type: "guid",
+            value: "02"
         }
     }],
     legend: {
         enabled: true,
-        position: 'top',
+        position: "top",
     },
     separators: {
-        thousand: ',',
-        decimal: '.'
+        thousand: ",",
+        decimal: "."
     }
 }
 ```

--- a/docs/10_vis__headline_component.md
+++ b/docs/10_vis__headline_component.md
@@ -14,7 +14,7 @@ Headlines have two sections: Measure (primary) and Measure (secondary). You can 
 ## Structure
 
 ```jsx
-import { Headline } from '@gooddata/sdk-ui-charts';
+import { Headline } from "@gooddata/sdk-ui-charts";
 
 <Headline
     primaryMeasure={<measure>}
@@ -26,7 +26,7 @@ import { Headline } from '@gooddata/sdk-ui-charts';
 ### Headline with a single measure (primary measure)
 
 ```jsx
-import { Headline } from '@gooddata/sdk-ui-charts';
+import { Headline } from "@gooddata/sdk-ui-charts";
 import { Ldm } from "./ldm";
 
 <Headline
@@ -37,7 +37,7 @@ import { Ldm } from "./ldm";
 ### Headline with two measures (primary and secondary measures)
 
 ```jsx
-import { Headline } from '@gooddata/sdk-ui-charts';
+import { Headline } from "@gooddata/sdk-ui-charts";
 import { Ldm } from "./ldm";
 
 <Headline

--- a/docs/10_vis__heatmap_component.md
+++ b/docs/10_vis__heatmap_component.md
@@ -11,8 +11,8 @@ A **heatmap** represents data as a matrix where individual values are represente
 ## Structure
 
 ```jsx
-import '@gooddata/sdk-ui-charts/styles/css/main.css';
-import { Heatmap } from '@gooddata/sdk-ui-charts';
+import "@gooddata/sdk-ui-charts/styles/css/main.css";
+import { Heatmap } from "@gooddata/sdk-ui-charts";
 
 <Heatmap
     measure={<measure>}
@@ -29,23 +29,23 @@ The following example shows the supported `config` structure with sample values.
     xaxis: {
         visible: true,
         labelsEnabled: true,
-        rotation: 'auto'
+        rotation: "auto"
     },
     yaxis: {
         visible: true,
         labelsEnabled: true,
-        rotation: 'auto'
+        rotation: "auto"
     },
     legend: {
         enabled: true,
-        position: 'top'
+        position: "top"
     },
     dataLabels: {
-        visible: 'auto'
+        visible: "auto"
     },
     separators: {
-        thousand: ',',
-        decimal: '.'
+        thousand: ",",
+        decimal: "."
     }
 }
 ```
@@ -53,8 +53,8 @@ The following example shows the supported `config` structure with sample values.
 ## Example
 
 ```jsx
-import '@gooddata/sdk-ui-charts/styles/css/main.css';
-import { Heatmap } from '@gooddata/sdk-ui-charts';
+import "@gooddata/sdk-ui-charts/styles/css/main.css";
+import { Heatmap } from "@gooddata/sdk-ui-charts";
 
 import { Ldm } from "./ldm";
 

--- a/docs/10_vis__insight_view.md
+++ b/docs/10_vis__insight_view.md
@@ -10,8 +10,8 @@ The **InsightView component** is a generic component that renders insights creat
 ## Structure
 
 ```jsx
-import '@gooddata/sdk-ui-ext/styles/css/main.css';
-import { InsightView } from '@gooddata/sdk-ui-ext';
+import "@gooddata/sdk-ui-ext/styles/css/main.css";
+import { InsightView } from "@gooddata/sdk-ui-ext";
 
 <div style={{ height: 400, width: 600 }}>
     <InsightView
@@ -22,8 +22,8 @@ import { InsightView } from '@gooddata/sdk-ui-ext';
 ```
 
 ```jsx
-import '@gooddata/sdk-ui-ext/styles/css/main.css';
-import { InsightView } from '@gooddata/sdk-ui-ext';
+import "@gooddata/sdk-ui-ext/styles/css/main.css";
+import { InsightView } from "@gooddata/sdk-ui-ext";
 
 <div style={{ height: 400, width: 600 }}>
     <InsightView
@@ -37,17 +37,17 @@ import { InsightView } from '@gooddata/sdk-ui-ext';
 ## Example
 
 ```jsx
-import '@gooddata/sdk-ui-ext/styles/css/main.css';
-import { InsightView } from '@gooddata/sdk-ui-ext';
+import "@gooddata/sdk-ui-ext/styles/css/main.css";
+import { InsightView } from "@gooddata/sdk-ui-ext";
 
 <div style={{ height: 400, width: 600 }}>
     <InsightView
         identifier="aoJqpe5Ib4mO"
         config={{
-            colors: ['rgb(195, 49, 73)', 'rgb(168, 194, 86)'],
+            colors: ["rgb(195, 49, 73)", "rgb(168, 194, 86)"],
             legend: {
                 enabled: true,
-                position: 'bottom'
+                position: "bottom"
             }
         }}
     />
@@ -65,7 +65,7 @@ To properly render the referenced table or chart, the InsightView component need
 The amount of the cached information does not impact performance in any way. However, you can manually clear the cache whenever needed (for example, after logging out, when switching projects or leaving a page with visualizations using the GoodData.UI components).
 
 ```javascript
-import { clearInsightViewCaches } from '@gooddata/sdk-ui-ext';
+import { clearInsightViewCaches } from "@gooddata/sdk-ui-ext";
 ...
 clearInsightViewCaches();
 ...

--- a/docs/10_vis__kpi_component.md
+++ b/docs/10_vis__kpi_component.md
@@ -10,7 +10,7 @@ A **KPI** \(Key Performance Indicator\) renders a measure calculated by the Good
 ## Structure
 
 ```jsx
-import { Kpi } from '@gooddata/react-components';
+import { Kpi } from "@gooddata/react-components";
 
 <Kpi
     measure="<measure-identifier>"
@@ -25,14 +25,14 @@ import { Kpi } from '@gooddata/react-components';
 The following sample KPI calculates the total sales in California:
 
 ```jsx
-import { Kpi } from '@gooddata/sdk-ui';
+import { Kpi } from "@gooddata/sdk-ui";
 import { newPositiveAttributeFilter } from "@gooddata/sdk-model";
 import { Ldm } from "./ldm";
 
 <Kpi
     measure={Ldm.$TotalSales}
     filters={[
-        newPositiveAttributeFilter(Ldm.StateName, ['California'])
+        newPositiveAttributeFilter(Ldm.StateName, ["California"])
     ]}
 />
 ```
@@ -44,6 +44,6 @@ import { Ldm } from "./ldm";
 | measure | true | string | The measure URI |
 | filters | false | [FilterItem[]](30_tips__filter_visual_components.md) | An array of filter definitions |
 | format | false | string | The measure format. If specified, overrides the format stored with the measure. |
-| separators | false | object | The format of the thousands separator and decimal separator used in measures. The default is `{ thousand: ',', decimal: '.' }`. For more information about setting the regional number format in a GoodData account, see [Set Default Number Format for your User Account](https://help.gooddata.com/display/doc/Set+Default+Number+Format+for+your+User+Account). |
+| separators | false | object | The format of the thousands separator and decimal separator used in measures. The default is `{ thousand: ",", decimal: "." }`. For more information about setting the regional number format in a GoodData account, see [Set Default Number Format for your User Account](https://help.gooddata.com/display/doc/Set+Default+Number+Format+for+your+User+Account). |
 | onError | false | function | Custom error handler. Called with the argument containing the state and original error message, for example, `{ status:ErrorStates.BAD_REQUEST,error: {...} }`. See the [full list of error states](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui/src/base/errors/GoodDataSdkError.ts). Defaults to `console.error`. |
 | onLoadingChanged | false | function | Custom loading handler. Called when a KPI changes to/from the loading state. Called with the argument denoting a valid state, for example, `{ isLoading:false}`. |

--- a/docs/10_vis__line_chart_component.md
+++ b/docs/10_vis__line_chart_component.md
@@ -12,8 +12,8 @@ A **line chart** shows data as line-connected dots. Line charts can display eith
 ## Structure
 
 ```jsx
-import '@gooddata/sdk-ui-charts/styles/css/main.css';
-import { LineChart } from '@gooddata/sdk-ui-charts';
+import "@gooddata/sdk-ui-charts/styles/css/main.css";
+import { LineChart } from "@gooddata/sdk-ui-charts";
 
 <LineChart
     measures={<measures>}
@@ -25,8 +25,8 @@ import { LineChart } from '@gooddata/sdk-ui-charts';
 ## Example
 
 ```jsx
-import '@gooddata/sdk-ui-charts/styles/css/main.css';
-import { LineChart } from '@gooddata/sdk-ui-charts';
+import "@gooddata/sdk-ui-charts/styles/css/main.css";
+import { LineChart } from "@gooddata/sdk-ui-charts";
 import { Ldm } from "./ldm";
 
 const style = { height: 300 };
@@ -61,16 +61,16 @@ The following example shows the supported `config` structure with sample values.
 
 ```javascript
 {
-    colors: ['rgb(195, 49, 73)', 'rgb(168, 194, 86)'],
+    colors: ["rgb(195, 49, 73)", "rgb(168, 194, 86)"],
     colorPalette: [{
-        guid: '01',
+        guid: "01",
         fill: {
             r: 195,
             g: 49,
             b: 73
         }
     }, {
-        guid: '02',
+        guid: "02",
         fill: {
             r: 168,
             g: 194,
@@ -79,38 +79,38 @@ The following example shows the supported `config` structure with sample values.
     }],
     colorMapping: [{
         predicate: (headerItem) => {
-            return headerItem.measureHeaderItem && (headerItem.measureHeaderItem.localIdentifier === 'm1_localIdentifier')
+            return headerItem.measureHeaderItem && (headerItem.measureHeaderItem.localIdentifier === "m1_localIdentifier")
         },
         color: {
-            type: 'guid',
-            value: '02'
+            type: "guid",
+            value: "02"
         }
     }],
     xaxis: {
         visible: true,
         labelsEnabled: true,
-        rotation: 'auto'
+        rotation: "auto"
     },
     yaxis: {
         visible: true,
         labelsEnabled: true,
-        rotation: 'auto',
-        min: '20',
-        max: '30'
+        rotation: "auto",
+        min: "20",
+        max: "30"
     },
     legend: {
         enabled: true,
-        position: 'top',
+        position: "top",
     },
     dataLabels: {
-        visible: 'auto'
+        visible: "auto"
     },
     grid: {
         enabled: true
     }
     separators: {
-        thousand: ',',
-        decimal: '.'
+        thousand: ",",
+        decimal: "."
     }
 }
 ```

--- a/docs/10_vis__measure_value_filter_component.md
+++ b/docs/10_vis__measure_value_filter_component.md
@@ -125,6 +125,6 @@ If you want to use your own custom button for toggling the filter dropdown, use 
 The component has all the same properties as the Measure Value Filter component (see [Properties](#Properties)) with the following exceptions:
 * The `buttonTitle` property is irrelevant for the  Measure Value Filter Dropdown component.
 * The `onCancel` property is mandatory for the  Measure Value Filter Dropdown component, because it is supposed to be used to hide the dropdown.
-* The Measure Value Filter Dropdown component has one additional property, `anchorEl`. This optional property specifies the element that the dropdown is aligned to, which is typically your toggle button. The property can be an event target or a string and defaults to `'body'`.
+* The Measure Value Filter Dropdown component has one additional property, `anchorEl`. This optional property specifies the element that the dropdown is aligned to, which is typically your toggle button. The property can be an event target or a string and defaults to `"body"`.
 
 Check out our [live examples](https://github.com/gooddata/gooddata-ui-sdk/tree/master/examples/sdk-examples) for demonstration.

--- a/docs/10_vis__pie_chart.md
+++ b/docs/10_vis__pie_chart.md
@@ -12,8 +12,8 @@ A **pie chart** shows data as proportional segments of a disc. Pie charts can be
 ## Structure
 
 ```jsx
-import '@gooddata/sdk-ui-charts/styles/css/main.css';
-import { PieChart } from '@gooddata/sdk-ui-charts';
+import "@gooddata/sdk-ui-charts/styles/css/main.css";
+import { PieChart } from "@gooddata/sdk-ui-charts";
 
 <PieChart
     measures={<measures>}
@@ -25,8 +25,8 @@ import { PieChart } from '@gooddata/sdk-ui-charts';
 ## Example
 
 ```jsx
-import '@gooddata/sdk-ui-charts/styles/css/main.css';
-import { PieChart } from '@gooddata/sdk-ui-charts';
+import "@gooddata/sdk-ui-charts/styles/css/main.css";
+import { PieChart } from "@gooddata/sdk-ui-charts";
 import { Ldm } from "./ldm";
 
 const style = { height: 300 };
@@ -59,16 +59,16 @@ The following example shows the supported `config` structure with sample values.
 
 ```javascript
 {
-    colors: ['rgb(195, 49, 73)', 'rgb(168, 194, 86)'],
+    colors: ["rgb(195, 49, 73)", "rgb(168, 194, 86)"],
     colorPalette: [{
-        guid: '01',
+        guid: "01",
         fill: {
             r: 195,
             g: 49,
             b: 73
         }
     }, {
-        guid: '02',
+        guid: "02",
         fill: {
             r: 168,
             g: 194,
@@ -77,23 +77,23 @@ The following example shows the supported `config` structure with sample values.
     }],
     colorMapping: [{
         predicate: (headerItem) => {
-            return headerItem.measureHeaderItem && (headerItem.measureHeaderItem.localIdentifier === 'm1_localIdentifier')
+            return headerItem.measureHeaderItem && (headerItem.measureHeaderItem.localIdentifier === "m1_localIdentifier")
         },
         color: {
-            type: 'guid',
-            value: '02'
+            type: "guid",
+            value: "02"
         }
     }],
     legend: {
         enabled: true,
-        position: 'top',
+        position: "top",
     },
     dataLabels: {
-        visible: 'auto'
+        visible: "auto"
     },
     separators: {
-        thousand: ',',
-        decimal: '.'
+        thousand: ",",
+        decimal: "."
     }
 }
 ```

--- a/docs/10_vis__pivot_table_component.md
+++ b/docs/10_vis__pivot_table_component.md
@@ -18,8 +18,8 @@ The following pivot table shows franchise fees (a measure), which are split down
 ## Structure
 
 ```jsx
-import '@gooddata/sdk-ui-pivot/styles/css/main.css';
-import { PivotTable } from '@gooddata/sdk-ui-pivot';
+import "@gooddata/sdk-ui-pivot/styles/css/main.css";
+import { PivotTable } from "@gooddata/sdk-ui-pivot";
 
 <PivotTable
     measures={<measures>}
@@ -36,8 +36,8 @@ import { PivotTable } from '@gooddata/sdk-ui-pivot';
 The following code sample shows an arrangement for a typical pivot table:
 
 ```jsx
-import '@gooddata/sdk-ui-pivot/styles/css/main.css';
-import { PivotTable } from '@gooddata/sdk-ui-pivot';
+import "@gooddata/sdk-ui-pivot/styles/css/main.css";
+import { PivotTable } from "@gooddata/sdk-ui-pivot";
 import { Ldm } from "./ldm";
 
 const style = { height: 300 };
@@ -56,8 +56,8 @@ const style = { height: 300 };
 You can also use the Pivot Table component to create a regular (flat) table.
 
 ```jsx
-import '@gooddata/sdk-ui-pivot/styles/css/main.css';
-import { PivotTable } from '@gooddata/sdk-ui-pivot';
+import "@gooddata/sdk-ui-pivot/styles/css/main.css";
+import { PivotTable } from "@gooddata/sdk-ui-pivot";
 import { Ldm } from "./ldm";
 
 const style = { height: 300 };
@@ -79,8 +79,8 @@ You can [sort](50_custom__result.md#sorting) rows and attribute columns in any p
 ### Example: Sorting by measure
 
 ```jsx
-import '@gooddata/sdk-ui-pivot/styles/css/main.css';
-import { PivotTable } from '@gooddata/sdk-ui-pivot';
+import "@gooddata/sdk-ui-pivot/styles/css/main.css";
+import { PivotTable } from "@gooddata/sdk-ui-pivot";
 import { newMeasureSort, newAttributeLocator } from "@gooddata/sdk-model";
 import { Ldm } from "./ldm";
 import { monthDateIdentifierJanuary } from "./ldm/ext";
@@ -384,8 +384,8 @@ const config = {
         aggregationsSubMenu: true
     },
     separators: {
-        thousand: ',',
-        decimal: '.'
+        thousand: ",",
+        decimal: "."
     },
     columnSizing: {
         defaultWidth: "viewport",

--- a/docs/10_vis__ranking_filter_component.md
+++ b/docs/10_vis__ranking_filter_component.md
@@ -23,7 +23,7 @@ import { RankingFilter } from "@gooddata/sdk-ui-filters";
   measureItems={<visualization-measures>}
   attributeItems={<visualization-attributes}
 />
-```     
+```
 
 ## Example
 
@@ -33,7 +33,7 @@ The following example shows a table displaying one measure sliced by one attribu
 import React, { useState } from "react";
 import { PivotTable } from "@gooddata/sdk-ui-pivot";
 import { newRankingFilter, localIdRef, measureLocalId, attributeLocalId } from "@gooddata/sdk-model";
-import { RankingFilter, IMeasureDropdownItem, IAttributeDropdownItem } from "@gooddata/sdk-ui-filters"; 
+import { RankingFilter, IMeasureDropdownItem, IAttributeDropdownItem } from "@gooddata/sdk-ui-filters";
 import { LdmExt } from "../../ldm";
 
 const measures = [LdmExt.FranchiseFees, LdmExt.FranchisedSales];
@@ -76,10 +76,10 @@ export const RankingFilterExample: React.FC = () => {
             />
             <hr className="separator" />
             <div style={{ height: 300 }} className="s-pivot-table">
-                <PivotTable 
-                    measures={measures} 
-                    rows={attributes} 
-                    filters={[filter]} 
+                <PivotTable
+                    measures={measures}
+                    rows={attributes}
+                    filters={[filter]}
                 />
             </div>
         </React.Fragment>
@@ -110,6 +110,6 @@ If you want to use your own custom button for toggling the filter dropdown, use 
 The component has all the same properties as the Ranking Filter component (see [Properties](#Properties)) with the following exceptions:
 * The `buttonTitle` property is irrelevant for the Ranking Filter Dropdown component.
 * The `onCancel` property is mandatory for the Ranking Filter Dropdown component, because it is supposed to be used to hide the dropdown.
-* The Ranking Filter Dropdown component has one additional property, `anchorEl`. This optional property specifies the element that the dropdown is aligned to, which is typically your toggle button. The property can be an event target or a string and defaults to `'body'`.
+* The Ranking Filter Dropdown component has one additional property, `anchorEl`. This optional property specifies the element that the dropdown is aligned to, which is typically your toggle button. The property can be an event target or a string and defaults to `"body"`.
 
 Check out our [live examples](https://github.com/gooddata/gooddata-ui-sdk/tree/master/examples/sdk-examples) for demonstration.

--- a/docs/10_vis__scatter_plot_component.md
+++ b/docs/10_vis__scatter_plot_component.md
@@ -13,8 +13,8 @@ Scatter plots are useful for analyzing trends between two measures or for tracki
 ## Structure
 
 ```jsx
-import '@gooddata/sdk-ui-charts/styles/css/main.css';
-import { ScatterPlot } from '@gooddata/sdk-ui-charts';
+import "@gooddata/sdk-ui-charts/styles/css/main.css";
+import { ScatterPlot } from "@gooddata/sdk-ui-charts";
 
 <ScatterPlot
     xAxisMeasure={<measure>}
@@ -28,8 +28,8 @@ import { ScatterPlot } from '@gooddata/sdk-ui-charts';
 ## Example
 
 ```jsx
-import '@gooddata/sdk-ui-charts/styles/css/main.css';
-import { ScatterPlot } from '@gooddata/sdk-ui-charts';
+import "@gooddata/sdk-ui-charts/styles/css/main.css";
+import { ScatterPlot } from "@gooddata/sdk-ui-charts";
 import { Ldm } from "./ldm";
 
 const style = { height: 300 };
@@ -65,16 +65,16 @@ The following example shows the supported `config` structure with sample values.
 
 ```javascript
 {
-    colors: ['rgb(195, 49, 73)', 'rgb(168, 194, 86)'],
+    colors: ["rgb(195, 49, 73)", "rgb(168, 194, 86)"],
     colorPalette: [{
-        guid: '01',
+        guid: "01",
         fill: {
             r: 195,
             g: 49,
             b: 73
         }
     }, {
-        guid: '02',
+        guid: "02",
         fill: {
             r: 168,
             g: 194,
@@ -83,36 +83,36 @@ The following example shows the supported `config` structure with sample values.
     }],
     colorMapping: [{
         predicate: (headerItem) => {
-            return headerItem.measureHeaderItem && (headerItem.measureHeaderItem.localIdentifier === 'm1_localIdentifier')
+            return headerItem.measureHeaderItem && (headerItem.measureHeaderItem.localIdentifier === "m1_localIdentifier")
         },
         color: {
-            type: 'guid',
-            value: '02'
+            type: "guid",
+            value: "02"
         }
     }],
     xaxis: {
         visible: true,
         labelsEnabled: true,
-        rotation: 'auto',
-        min: '20',
-        max: '30'
+        rotation: "auto",
+        min: "20",
+        max: "30"
     },
     yaxis: {
         visible: true,
         labelsEnabled: true,
-        rotation: 'auto',
-        min: '40',
-        max: '50'
+        rotation: "auto",
+        min: "40",
+        max: "50"
     },
     dataLabels: {
-        visible: 'auto'
+        visible: "auto"
     },
     grid: {
         enabled: true
     }
     separators: {
-        thousand: ',',
-        decimal: '.'
+        thousand: ",",
+        decimal: "."
     }
 }
 ```

--- a/docs/10_vis__treemap_component.md
+++ b/docs/10_vis__treemap_component.md
@@ -11,8 +11,8 @@ A **treemap** presents data hierarchically as nested rectangles. Treemaps are us
 ## Structure
 
 ```jsx
-import '@gooddata/sdk-ui-charts/styles/css/main.css';
-import { Treemap } from '@gooddata/sdk-ui-charts';
+import "@gooddata/sdk-ui-charts/styles/css/main.css";
+import { Treemap } from "@gooddata/sdk-ui-charts";
 
 <Treemap
     measures={<measures>}
@@ -26,8 +26,8 @@ import { Treemap } from '@gooddata/sdk-ui-charts';
 ## Example
 
 ```jsx
-import '@gooddata/sdk-ui-charts/styles/css/main.css';
-import { Treemap } from '@gooddata/sdk-ui-charts';
+import "@gooddata/sdk-ui-charts/styles/css/main.css";
+import { Treemap } from "@gooddata/sdk-ui-charts";
 import { Ldm } from "./ldm";
 
 const style = { height: 300 };
@@ -64,16 +64,16 @@ The following example shows the supported `config` structure with sample values.
 
 ```javascript
 {
-    colors: ['rgb(195, 49, 73)', 'rgb(168, 194, 86)'],
+    colors: ["rgb(195, 49, 73)", "rgb(168, 194, 86)"],
     colorPalette: [{
-        guid: '01',
+        guid: "01",
         fill: {
             r: 195,
             g: 49,
             b: 73
         }
     }, {
-        guid: '02',
+        guid: "02",
         fill: {
             r: 168,
             g: 194,
@@ -82,23 +82,23 @@ The following example shows the supported `config` structure with sample values.
     }],
     colorMapping: [{
         predicate: (headerItem) => {
-            return headerItem.measureHeaderItem && (headerItem.measureHeaderItem.localIdentifier === 'm1_localIdentifier')
+            return headerItem.measureHeaderItem && (headerItem.measureHeaderItem.localIdentifier === "m1_localIdentifier")
         },
         color: {
-            type: 'guid',
-            value: '02'
+            type: "guid",
+            value: "02"
         }
     }],
     legend: {
         enabled: true,
-        position: 'right',
+        position: "right",
     },
     dataLabels: {
-        visible: 'auto'
+        visible: "auto"
     },
     separators: {
-        thousand: ',',
-        decimal: '.'
+        thousand: ",",
+        decimal: "."
     }
 }
 ```

--- a/docs/15_props__chart_config.md
+++ b/docs/15_props__chart_config.md
@@ -12,52 +12,52 @@ This article describes the options for configuring a chart.
 ```javascript
 {
     chart: {
-        verticalAlign: 'top' // 'top' | 'middle' | 'bottom'
+        verticalAlign: "top" // "top" | "middle" | "bottom"
     },
-    colors: ['rgb(195, 49, 73)', 'rgb(168, 194, 86)'], // array of strings
+    colors: ["rgb(195, 49, 73)", "rgb(168, 194, 86)"], // array of strings
     xaxis: {
         visible: true, // boolean
         labelsEnabled: true, // boolean
-        rotation: 'auto', // 'auto' or numeral string
-        min: '10', // numeral string
-        max: '20' // numeral string
+        rotation: "auto", // "auto" or numeral string
+        min: "10", // numeral string
+        max: "20" // numeral string
     },
     yaxis: {
         visible: true, // boolean
         labelsEnabled: true, // boolean
-        rotation: 'auto', // string
-        min: '30', // numeral string
-        max: '40' // numeral string
+        rotation: "auto", // string
+        min: "30", // numeral string
+        max: "40" // numeral string
     },
     secondary_yaxis: {
         visible: true, // boolean
         labelsEnabled: true, // boolean
-        rotation: 'auto', // string
-        min: '300', // numeral string
-        max: '400', // numeral string
-        measures: ['measureLocalIdentifier']
+        rotation: "auto", // string
+        min: "300", // numeral string
+        max: "400", // numeral string
+        measures: ["measureLocalIdentifier"]
     },
     legend: {
         enabled: true, // boolean
-        position: 'bottom', // 'top' | 'left' | 'right' | 'bottom'
+        position: "bottom", // "top" | "left" | "right" | "bottom"
     },
     dataLabels: {
-        visible: 'auto' // 'auto' | true | false
+        visible: "auto" // "auto" | true | false
     },
     dataPoints: {
-        visible: true // 'auto' | true | false
+        visible: true // "auto" | true | false
     },
     grid: {
         enabled: true // boolean
     },
     separators: {
-        thousand: ',',
-        decimal: '.'
+        thousand: ",",
+        decimal: "."
     },
     stackMeasures: true, // boolean
     stackMeasuresToPercent: true, // boolean
-    primaryChartType: 'column', // string
-    secondaryChartType: 'area', // string
+    primaryChartType: "column", // string
+    secondaryChartType: "area", // string
     dualAxis: false // boolean
 }
 ```
@@ -70,14 +70,14 @@ You can configure a vertical alignment for [pie charts](10_vis__pie_chart.md) an
 To align a chart vertically, set `config.chart.verticalAlign` to one of the possible values: `top`, `middle`, `bottom`. If not set, it defaults to `middle`.
 
 ```jsx
-import { InsightView } from '@gooddata/sdk-ui-ext';
+import { InsightView } from "@gooddata/sdk-ui-ext";
 
 // Example of embedding a visualization with a custom chart alignment
 <InsightView
     identifier=<InsightView-id>
     config={{
         chart: {
-            verticalAlign: 'bottom'
+            verticalAlign: "bottom"
         }
     }}
 />
@@ -100,19 +100,19 @@ If you have more than one option configured for a visualization, the following r
 The following are examples of a color array:
 
 ```javascript
-['rgb(195, 49, 73)', 'rgb(168, 194, 86)']
+["rgb(195, 49, 73)", "rgb(168, 194, 86)"]
 
 ```
 
 ```javascript
-['#fa0510', '#AA2030']
+["#fa0510", "#AA2030"]
 
 ```
 
 If there are fewer colors than data points, then the colors are repeated. For example, here is how colors will be used for two colors and three data points:
 
 ```javascript
-['rgb(195, 49, 73)', 'rgb(168, 194, 86)', 'rgb(195, 49, 73)']
+["rgb(195, 49, 73)", "rgb(168, 194, 86)", "rgb(195, 49, 73)"]
 ```
 
 To change colors in a chart, provide a `config` for each component where you want to change colors, or create a wrapped components with a `config` baked in.
@@ -120,13 +120,13 @@ To change colors in a chart, provide a `config` for each component where you wan
 **NOTE:** Heatmaps use only the first color from the provided colors as the base color, and generate the other colors themselves.
 
 ```jsx
-import { InsightView } from '@gooddata/sdk-ui-ext';
+import { InsightView } from "@gooddata/sdk-ui-ext";
 
 // Example of embedding a visualization with custom colors and palette options
 <InsightView
     identifier=<InsightView-id>
     config={{
-        colors: ['rgb(195, 49, 73)', 'rgb(168, 194, 86)']
+        colors: ["rgb(195, 49, 73)", "rgb(168, 194, 86)"]
     }}
 />
 ```
@@ -142,28 +142,28 @@ If you [uploaded a custom color palette](https://help.gooddata.com/display/doc/I
 To override the uploaded custom color palette for a specific visualization, define the `colorPalette` property for this visualization.
 
 ```jsx
-import { InsightView } from '@gooddata/sdk-ui-ext';
+import { InsightView } from "@gooddata/sdk-ui-ext";
 
 // Example of embedding a visualization with a custom palette
 <InsightView
    identifier=<InsightView-id>
    config={{
        colorPalette: [{
-            guid: '01',
+            guid: "01",
             fill: {
                 r: 195,
                 g: 49,
                 b: 73
             }
         }, {
-            guid: '02',
+            guid: "02",
             fill: {
                 r: 168,
                 g: 194,
                 b: 86
             }
         }, {
-            guid: '03',
+            guid: "03",
             fill: {
                 r: 243,
                 g: 217,
@@ -193,7 +193,7 @@ The `colorMapping` property contains an array of objects. Each object is represe
 The following example shows how to assign the color with GUID `02` to the measure with the local identifier `m1_localIdentifier`, and the black color to the measure with the local identifier `m2_localIdentifier`:
 
 ```jsx
-import { InsightView } from '@gooddata/sdk-ui-ext';
+import { InsightView } from "@gooddata/sdk-ui-ext";
 
 // Example of embedding a visualization with custom color mapping
 <InsightView
@@ -201,18 +201,18 @@ import { InsightView } from '@gooddata/sdk-ui-ext';
     config={{
         colorMapping: [{
             predicate: (headerItem) => {
-                return headerItem.measureHeaderItem && (headerItem.measureHeaderItem.localIdentifier === 'm1_localIdentifier')
+                return headerItem.measureHeaderItem && (headerItem.measureHeaderItem.localIdentifier === "m1_localIdentifier")
             },
             color: {
-                type: 'guid',
-                value: '02'
+                type: "guid",
+                value: "02"
             }
         }, {
             predicate: (headerItem) => {
-                return headerItem.measureHeaderItem && (headerItem.measureHeaderItem.localIdentifier === 'm2_localIdentifier')
+                return headerItem.measureHeaderItem && (headerItem.measureHeaderItem.localIdentifier === "m2_localIdentifier")
             },
             color: {
-                type: 'rgb',
+                type: "rgb",
                 value: {
                     r: 0,
                     g: 0,
@@ -228,10 +228,10 @@ Within one visualization, the `colorMapping` property overrides the `colorPalett
 ## Change legend visibility and position
 
 * To hide the legend, set `config.legend.enabled` to `false`.
-* To change the legend position, adjust the `config.legend.position` property \(`'left'`/`'right'`/`'top'`/`'bottom'`\).
+* To change the legend position, adjust the `config.legend.position` property \(`"left"`/`"right"`/`"top"`/`"bottom"`\).
 
 ```jsx
-import { InsightView } from '@gooddata/sdk-ui-ext';
+import { InsightView } from "@gooddata/sdk-ui-ext";
 
 // Example of embedding a visualization with a custom legend position
 <InsightView
@@ -239,7 +239,7 @@ import { InsightView } from '@gooddata/sdk-ui-ext';
     config={{
         legend: {
             enabled: true,
-            position: 'bottom' // 'left', 'right', 'top'
+            position: "bottom" // "left", "right", "top"
         }
     }}
 />
@@ -251,15 +251,15 @@ import { InsightView } from '@gooddata/sdk-ui-ext';
 * To change the decimal separator, adjust the `config.separators.decimal` property.
 
 ```jsx
-import { InsightView } from '@gooddata/sdk-ui-ext';
+import { InsightView } from "@gooddata/sdk-ui-ext";
 
 // Example of embedding a visualization with a custom separator in the number format
 <InsightView
     identifier=<InsightView-id>
     config={{
         separators: {
-            thousand: ',',
-            decimal: '.'
+            thousand: ",",
+            decimal: "."
         }
     }}
 />
@@ -282,7 +282,7 @@ The properties listed in this section are specific to the **X** axis. To get the
     **NOTE:** If the axis represents more than one attribute/measure, the `config.xaxis.name.visible` and `config.xaxis.name.position` properties are both ignored, and the axis name is hidden.
 
 ```jsx
-import { InsightView } from '@gooddata/sdk-ui-ext';
+import { InsightView } from "@gooddata/sdk-ui-ext";
 
 // Example of embedding a visualization with settings for the x-axis
 <InsightView
@@ -291,23 +291,23 @@ import { InsightView } from '@gooddata/sdk-ui-ext';
         xaxis: {
             visible: false,
             labelsEnabled: false,
-            rotation: '-90',
-            min: '150',
-            max: '440',
+            rotation: "-90",
+            min: "150",
+            max: "440",
             name: {
-                position: 'low', // 'low', 'middle', 'high'
+                position: "low", // "low", "middle", "high"
             }
         },
         secondary_xaxis: {
             visible: true,
             labelsEnabled: true,
-            rotation: '-90',
-            min: '1500',
-            max: '4400',
+            rotation: "-90",
+            min: "1500",
+            max: "4400",
             name: {
                 visible: false
             }
-            measures: ['measureLocalIdentifier1', 'measureLocalIdentifier2']
+            measures: ["measureLocalIdentifier1", "measureLocalIdentifier2"]
         }
     }}
 />
@@ -322,7 +322,7 @@ import { InsightView } from '@gooddata/sdk-ui-ext';
     * [Combo charts](10_vis__combo_chart_component.md) with at least one of the combined charts being a [line chart](10_vis__line_chart_component.md) or an [area chart](10_vis__area_chart_component.md).
 
 ```jsx
-import { InsightView } from '@gooddata/sdk-ui-ext';
+import { InsightView } from "@gooddata/sdk-ui-ext";
 
 // Example of embedding a visualization with settings for the canvas
 <InsightView
@@ -355,7 +355,7 @@ import { InsightView } from '@gooddata/sdk-ui-ext';
     * For charts with the secondary axis, `config.stackMeasuresToPercent` is applied only to the left axis.
 
 ```jsx
-import { InsightView } from '@gooddata/sdk-ui-ext';
+import { InsightView } from "@gooddata/sdk-ui-ext";
 
 // Example of embedding a visualization with stacking
 <InsightView

--- a/docs/15_props__date_filter_option.md
+++ b/docs/15_props__date_filter_option.md
@@ -120,8 +120,8 @@ const dateFilterOptions = {
     absoluteForm: {
         localIdentifier: "90bad814-a193-429f-b88c-118cd00f2168",
         type: "absoluteForm",
-        from: dateFrom.toISOString().substr(0, 10), // 'YYYY-MM-DD'
-        to: new Date().toISOString().substr(0, 10), // 'YYYY-MM-DD'
+        from: dateFrom.toISOString().substr(0, 10), // "YYYY-MM-DD"
+        to: new Date().toISOString().substr(0, 10), // "YYYY-MM-DD"
         name: "Static period",
         visible: true,
     },

--- a/docs/15_props__drillable_item.md
+++ b/docs/15_props__drillable_item.md
@@ -9,7 +9,7 @@ You can enable eventing and drilling in a visualization. Drilling is the process
 
 To add drilling, use function predicates.
 
-> Before Version 6.2, you could implement drilling using a list of `drillableItems` that contained the URI or identifier of a measure or attribute (for example, `{ identifier: 'label.owner.department' }`  or `{ uri: '/gdc/md/projectHash/obj/1027' }`). While we do not recommend that you use this method anymore, it is still supported. For more information, see [DrillableItems](https://sdk.gooddata.com/gooddata-ui/docs/6.1.0/drillable_item.html) in the Version 6.1 documentation.
+> Before Version 6.2, you could implement drilling using a list of `drillableItems` that contained the URI or identifier of a measure or attribute (for example, `{ identifier: "label.owner.department" }`  or `{ uri: "/gdc/md/projectHash/obj/1027" }`). While we do not recommend that you use this method anymore, it is still supported. For more information, see [DrillableItems](https://sdk.gooddata.com/gooddata-ui/docs/6.1.0/drillable_item.html) in the Version 6.1 documentation.
 
 To turn on eventing and drilling, specify at least one drillableItem.
 
@@ -22,10 +22,10 @@ Drillable items can consist of the following entities:
 
 Visualization points that intersect any defined measures, attributes, or attribute values become drillable and will emit events when interacted with.
 
-**NOTE:** Ad-hoc measures (measures created from attribute or measures using 
-[computeRatio option](https://sdk.gooddata.com/gooddata-ui/docs/afm.html#show-a-measure-as-a-percentage) are defined 
-using URI or identifier in the execution. When you want set up drilling for such ad-hoc measures, use same parameter (URI or identifier) 
-as you used in the execution. Keep on mind, that Analytical Designer creates such measures only using URI. When you want to 
+**NOTE:** Ad-hoc measures (measures created from attribute or measures using
+[computeRatio option](https://sdk.gooddata.com/gooddata-ui/docs/afm.html#show-a-measure-as-a-percentage) are defined
+using URI or identifier in the execution. When you want set up drilling for such ad-hoc measures, use same parameter (URI or identifier)
+as you used in the execution. Keep on mind, that Analytical Designer creates such measures only using URI. When you want to
 activate drilling on ad-hoc measures created by Analytical Designer, you can use only URIs to activate drill.
 
 ## Structure
@@ -37,30 +37,30 @@ drillableItems: [
 ]
 ```
 
-`IHeaderPredicate` defines the function that accepts `IMappingHeader` and `context` as its parameters and returns 
-a `boolean` value. This function is executed against every measure and attribute in a visualization. If the function 
-returns `true`, the measure or attribute is drillable. If the function returns `false`, the measure or attribute is 
+`IHeaderPredicate` defines the function that accepts `IMappingHeader` and `context` as its parameters and returns
+a `boolean` value. This function is executed against every measure and attribute in a visualization. If the function
+returns `true`, the measure or attribute is drillable. If the function returns `false`, the measure or attribute is
 not drillable.
 
 You can program any logic to determine whether a particular measure or attribute should be drillable. However, this is not required often.
 
 ### Predicate factory helpers
 
-GoodData.UI SDK contains `HeaderPredicates` that helps you easily build predicate functions that cover most of the 
+GoodData.UI SDK contains `HeaderPredicates` that helps you easily build predicate functions that cover most of the
 common drill eventing use cases. You can import this factory directly from the `@gooddata/sdk-ui` package.
 
 `HeaderPredicates` provides the following predicate factory functions:
 
-* `uriMatch('<measure-or-attribute-uri>')`
+* `uriMatch("<measure-or-attribute-uri>")`
 
     The helper builds a predicate function that matches any measure or attribute in a visualization to the provided URI.
-* `identifierMatch('<measure-or-attribute-identifier>')`
-    
+* `identifierMatch("<measure-or-attribute-identifier>")`
+
     The helper builds a predicate function that matches any measure or attribute in a visualization to the provided identifier.
-* `composedFromUri('<measure-or-attribute-uri>')` 
+* `composedFromUri("<measure-or-attribute-uri>")`
 
     The helper builds a predicate function that matches any [arithmetic measure](20_misc__arithmetic_measure.md) in a visualization contaning measures to the provided URI in its tree of measures that the arithmetic measure is built from.
-* `composedFromIdentifier('<measure-or-attribute-identifier>')` 
+* `composedFromIdentifier("<measure-or-attribute-identifier>")`
 
     The helper builds a predicate function that matches any [arithmetic measure](20_misc__arithmetic_measure.md) in a visualization contaning measures to the provided identifier in its tree of measures that the arithmetic measure is built from.
 
@@ -68,15 +68,15 @@ common drill eventing use cases. You can import this factory directly from the `
 
 To enable event drilling, extend the `Visualization` component with a `drillableItems` property.
 
-In the `drillableItems` property, add an array of `IHeaderPredicate` functions that identifies the measures and 
+In the `drillableItems` property, add an array of `IHeaderPredicate` functions that identifies the measures and
 attributes that should become highlighted and drillable.
 
-**Example:** Drilling in a visualization enabled for the measure with either the identifier of `label.owner.department` 
+**Example:** Drilling in a visualization enabled for the measure with either the identifier of `label.owner.department`
 or the URI of `/gdc/md/la84vcyhrq8jwbu4wpipw66q2sqeb923/obj/9211`
 
 ```jsx
 // This is an example of event drilling on the visualization from the GoodSales demo project.
-import { HeaderPredicates } from '@gooddata/sdk-ui';
+import { HeaderPredicates } from "@gooddata/sdk-ui";
 
 function onDrillHandler(event) {
     // handle drill
@@ -85,21 +85,21 @@ function onDrillHandler(event) {
 <InsightView
   identifier="aby3polcaFxy"
   drillableItems={[
-    HeaderPredicates.uriMatch('/gdc/md/la84vcyhrq8jwbu4wpipw66q2sqeb923/obj/9211'),  
-    HeaderPredicates.identifierMatch('label.owner.department') 
+    HeaderPredicates.uriMatch("/gdc/md/la84vcyhrq8jwbu4wpipw66q2sqeb923/obj/9211"),
+    HeaderPredicates.identifierMatch("label.owner.department")
   ]}
   onDrill={onDrillHandler}
 />
 ```
 
-**Example:** Drilling in a visualization enabled for every [arithmetic measure](20_misc__arithmetic_measure.md) that 
-has a measure with either the identifier set to `label.owner.department` or the URI set 
-to `/gdc/md/la84vcyhrq8jwbu4wpipw66q2sqeb923/obj/9211` in its tree of measures that the arithmetic measure 
+**Example:** Drilling in a visualization enabled for every [arithmetic measure](20_misc__arithmetic_measure.md) that
+has a measure with either the identifier set to `label.owner.department` or the URI set
+to `/gdc/md/la84vcyhrq8jwbu4wpipw66q2sqeb923/obj/9211` in its tree of measures that the arithmetic measure
 is built from.
 
 ```jsx
 // This is an example of event drilling on the visualization from the GoodSales demo project.
-import { HeaderPredicates } from '@gooddata/sdk-ui';
+import { HeaderPredicates } from "@gooddata/sdk-ui";
 
 function onDrillHandler(event) {
     // handle drill
@@ -108,16 +108,16 @@ function onDrillHandler(event) {
 <InsightView
   identifier="aby3polcaFxy"
   drillableItems={[
-    HeaderPredicates.composedFromUri('/gdc/md/la84vcyhrq8jwbu4wpipw66q2sqeb923/obj/9211'),  
-    HeaderPredicates.composedFromIdentifier('label.owner.department')  
+    HeaderPredicates.composedFromUri("/gdc/md/la84vcyhrq8jwbu4wpipw66q2sqeb923/obj/9211"),
+    HeaderPredicates.composedFromIdentifier("label.owner.department")
   ]}
   onDrill={onDrillHandler}
 />
 ```
 
 Each event contains an object consisting of `dataView` and `drillContext`. The `dataView` contains the underlying data used
-to render the chart from which the drill event originates. The `drillContext` contains full context of which element the 
-user clicked. 
+to render the chart from which the drill event originates. The `drillContext` contains full context of which element the
+user clicked.
 
 ## Additional information
 

--- a/docs/15_props__error_component.md
+++ b/docs/15_props__error_component.md
@@ -14,7 +14,7 @@ The ErrorComponent indicator is supported by all visualization components.
 In the following example, the KPI shows neither the loading indicator nor the error message.
 
 ```jsx
-import { Kpi } from '@gooddata/sdk-ui';
+import { Kpi } from "@gooddata/sdk-ui";
 import { Ldm } from "./ldm";
 
 <Kpi
@@ -29,7 +29,7 @@ import { Ldm } from "./ldm";
 In the following example, the default ErrorComponent is replaced by a custom component.
 
 ```jsx
-import { Kpi } from '@gooddata/sdk-ui';
+import { Kpi } from "@gooddata/sdk-ui";
 import { Ldm } from "./ldm";
 
 const CustomError = ({

--- a/docs/15_props__loading_component.md
+++ b/docs/15_props__loading_component.md
@@ -14,9 +14,9 @@ The LoadingComponent indicator is supported by all visualization components.
 In the following example, the KPI shows neither the loading indicator nor the error message.
 
 ```jsx
-import { Kpi } from '@gooddata/sdk-ui';
+import { Kpi } from "@gooddata/sdk-ui";
 import { Ldm } from "./ldm";
- 
+
 <Kpi
     measure={Ldm.$FranchiseFees}
     format="<format>"
@@ -30,8 +30,8 @@ import { Ldm } from "./ldm";
 In the following example, the default LoadingComponent is customized with color, fixed size, indicator size, and speed of animation.
 
 ```jsx
-import React, { Component } from 'react';
-import { Kpi, LoadingComponent } from '@gooddata/sdk-ui';
+import React, { Component } from "react";
+import { Kpi, LoadingComponent } from "@gooddata/sdk-ui";
 import { Ldm } from "./ldm";
 
 export class CustomisedLoadingComponentExample extends Component {

--- a/docs/15_props__on_drill.md
+++ b/docs/15_props__on_drill.md
@@ -16,15 +16,15 @@ When a user clicks a [drillable item](15_props__drillable_item.md) in a visualiz
 
 ```jsx
 import { InsightView } from "@gooddata/sdk-ui-ext";
-import { HeaderPredicates } from '@gooddata/sdk-ui';
+import { HeaderPredicates } from "@gooddata/sdk-ui";
 
 <InsightView
    identifier="<visualization-identifier>"
    config={<chart-config>}
    onDrill={(event) => { console.log(event.dataView); }}
    drillableItems={[
-        HeaderPredicates.identifierMatch('drillable-Identifier1'), 
-        HeaderPredicates.uriMatch('/drillable-Uri2')
+        HeaderPredicates.identifierMatch("drillable-Identifier1"),
+        HeaderPredicates.uriMatch("/drillable-Uri2")
    ]}
 />
 ```

--- a/docs/15_props__on_export_ready.md
+++ b/docs/15_props__on_export_ready.md
@@ -47,14 +47,14 @@ export class Example extends React.Component {
     async doExport() {
         try {
             const result = await this.getExportedData({
-                format: 'xlsx',
+                format: "xlsx",
                 includeFilterContext: true,
                 mergeHeaders: true,
-                title: 'CustomTitle'
+                title: "CustomTitle"
             });
-            console.log('Export successfully: ', result.uri);
+            console.log("Export successfully: ", result.uri);
         } catch (error) {
-            console.log('Export error: ', error);
+            console.log("Export error: ", error);
         }
     }
 

--- a/docs/15_props__on_legend_ready.md
+++ b/docs/15_props__on_legend_ready.md
@@ -13,8 +13,8 @@ The `onLegendReady` parameter allows you to get a series from charts and to ren
 {
     legendItems: [
         {
-            name: 'Revenue', // the name of the series; must be a string
-            color: '#fff', // a HEX or RGB color; can be used directly in CSS
+            name: "Revenue", // the name of the series; must be a string
+            color: "#fff", // a HEX or RGB color; can be used directly in CSS
             onClick: Function // a function without any parameters, returns nothing; the trigger will toggle show/hide for the series in a visualization
         }
     ]

--- a/docs/20_misc__arithmetic_measure.md
+++ b/docs/20_misc__arithmetic_measure.md
@@ -64,12 +64,12 @@ import { PivotTable } from "@gooddata/sdk-ui-pivot";
 
 const measures = [
     // the first simple measure (operand)
-    newMeasure('boughtProductsIdentifier', m => m.alias('Bought products from supplier')),
-    newMeasure('soldProductsLocalIdentifier', m => m.alias('Sold products to customers')),
+    newMeasure("boughtProductsIdentifier", m => m.alias("Bought products from supplier")),
+    newMeasure("soldProductsLocalIdentifier", m => m.alias("Sold products to customers")),
     newArithmeticMeasure(
-        ['boughtProductsLocalIdentifier', 'soldProductsLocalIdentifier'],
-        'difference',
-        m => m.alias('Products remaining in warehouse')
+        ["boughtProductsLocalIdentifier", "soldProductsLocalIdentifier"],
+        "difference",
+        m => m.alias("Products remaining in warehouse")
     )
 ];
 
@@ -87,9 +87,9 @@ demonstrates passing measures by value to the different measure factory function
 import { newMeasure, newPopMeasure, newArithmeticMeasure } from "@gooddata/sdk-model";
 import { PivotTable } from "@gooddata/sdk-ui-pivot";
 
-const currentYear = newMeasure('measureIdentifier', m => m.alias("Current Year"));
+const currentYear = newMeasure("measureIdentifier", m => m.alias("Current Year"));
 // derived - data from previous year
-const previousYear = newPopMeasure(currentYear, 'attributeDisplayFormYearIdentifier',  m => m.alias("Previous Year"));
+const previousYear = newPopMeasure(currentYear, "attributeDisplayFormYearIdentifier", m => m.alias("Previous Year"));
 // arithmetic measure with custom format
 const change = newArithmeticMeasure(previousYear, currentYear, "change", m => m.alias("Change between years").format("$#,#0.0%"));
 

--- a/docs/20_misc__time_over_time_comparison.md
+++ b/docs/20_misc__time_over_time_comparison.md
@@ -40,8 +40,8 @@ where:
 import { PivotTable } from "@gooddata/sdk-ui-pivot";
 import { newMeasure, newPopMeasure } from "@gooddata/sdk-model";
 
-const masterMeasure = newMeasure('measureIdentifier', m => m.alias('Master Measure'));
-const popMeasure = newPopMeasure(masterMeasure, 'attributeYearIdentifier', m => m.alias("Same Period Previous Year"));
+const masterMeasure = newMeasure("measureIdentifier", m => m.alias("Master Measure"));
+const popMeasure = newPopMeasure(masterMeasure, "attributeYearIdentifier", m => m.alias("Same Period Previous Year"));
 
 const measures = [
     masterMeasure,
@@ -83,15 +83,15 @@ import { newMeasure, newPreviousPeriodMeasure, newRelativeDateFilter } from "@go
 import { PivotTable } from "@gooddata/sdk-ui-pivot";
 
 const filters = [
-    newRelativeDateFilter('dateDatasetIdentifier', 'GDC.time.date', -7, -1)
+    newRelativeDateFilter("dateDatasetIdentifier", "GDC.time.date", -7, -1)
 ];
 
 // master - last 7 days measure
-const masterMeasure = newMeasure('measureIdentifier', m => m.alias("Master Measure"));
+const masterMeasure = newMeasure("measureIdentifier", m => m.alias("Master Measure"));
 // derived - previous 7 days measure
 const previousPeriod = newPreviousPeriodMeasure(
                             masterMeasure,
-                            { dataSet: 'dateDatasetIdentifier', periodsAgo: 1},
+                            { dataSet: "dateDatasetIdentifier", periodsAgo: 1},
                             m => m.alias("Previous Period Measure")
                         );
 

--- a/docs/30_tips__cors.md
+++ b/docs/30_tips__cors.md
@@ -23,7 +23,7 @@ You can set up a proxy to bypass the CORS restriction on a local dev machine, be
 To set up a proxy, in your project's `/src` directory, create the `setupProxy.js` file with the following content:
 
 ```javascript
-const proxy = require('http-proxy-middleware');
+const proxy = require("http-proxy-middleware");
 
 module.exports = function (app) {
      app.use(proxy("/gdc", {
@@ -36,7 +36,7 @@ module.exports = function (app) {
              "origin": null
          },
          "onProxyReq": function(proxyReq, req, res) {
-             proxyReq.setHeader('accept-encoding', 'identity')
+             proxyReq.setHeader("accept-encoding", "identity")
          }
      }));
      app.use(proxy("/*.html", {

--- a/docs/30_tips__create_predicates.md
+++ b/docs/30_tips__create_predicates.md
@@ -10,7 +10,7 @@ Predicates allow you to create a match between elements (for example, a measure 
 For example, a predicate that creates a simple match based on an equation may look like the following:
 
 ```javascript
-(headerItem) => headerItem.measureHeaderItem.localIdentifier === 'm1_localIdentifier'
+(headerItem) => headerItem.measureHeaderItem.localIdentifier === "m1_localIdentifier"
 ```
 
 Here is an example of a predicate that increments the `callCounter` variable in the predicate's closure every time the predicate is called and returns `true` if `callCounter` is an even number:

--- a/docs/30_tips__embed_visualization.md
+++ b/docs/30_tips__embed_visualization.md
@@ -1,5 +1,5 @@
 ---
-title: Embed an Insight Created in Analytical Designer 
+title: Embed an Insight Created in Analytical Designer
 sidebar_label: Embed an Insight Created in Analytical Designer
 copyright: (C) 2007-2018 GoodData Corporation
 id: ht_embed_visualization
@@ -13,21 +13,21 @@ To embed an existing insight created in Analytical Designer, use the [InsightVie
 
 2. Import the InsightView component from the `@gooddata/sdk-ui-ext` package into your app:
     ```javascript
-    import { InsightView } from '@gooddata/sdk-ui-ext';
+    import { InsightView } from "@gooddata/sdk-ui-ext";
     ```
 
 3. Create an `InsightView` component in your app, and provide it with the project ID and the visualization identifier that you obtained at Step 1:
     ```jsx
-    import { InsightView } from '@gooddata/sdk-ui-ext';
-    import '@gooddata/sdk-ui-ext/styles/css/main.css';
+    import { InsightView } from "@gooddata/sdk-ui-ext";
+    import "@gooddata/sdk-ui-ext/styles/css/main.css";
 
     <InsightView
         identifier="aby3polcaFxy"
         config={{
-            colors: ['rgb(195, 49, 73)', 'rgb(168, 194, 86)'],
+            colors: ["rgb(195, 49, 73)", "rgb(168, 194, 86)"],
             legend: {
                 enabled: true,
-                position: 'bottom'
+                position: "bottom"
             }
         }}
     />

--- a/docs/30_tips__filter_visual_components.md
+++ b/docs/30_tips__filter_visual_components.md
@@ -86,12 +86,12 @@ A **relative date filter** shows data that falls within a time range defined rel
 
 | Value | Description |
 | :--- | :--- |
-| `'GDC.time.date'` | Days |
-| `'GDC.time.week'` | Weeks starting on Monday |
-| `'GDC.time.week_us'` | Weeks starting on Sunday |
-| `'GDC.time.month'` | Months
-| `'GDC.time.quarter'` | Quarters of a year |
-| `'GDC.time.year'` | Years |
+| `"GDC.time.date"` | Days |
+| `"GDC.time.week"` | Weeks starting on Monday |
+| `"GDC.time.week_us"` | Weeks starting on Sunday |
+| `"GDC.time.month"` | Months
+| `"GDC.time.quarter"` | Quarters of a year |
+| `"GDC.time.year"` | Years |
 
 The `from` and `to` properties set the number of granularity units (for example, weeks) before or after the current date. That is, `from` and `to`  define the filter range.
 
@@ -127,19 +127,19 @@ where:
 **Last 7 days \(yesterday and 6 days before\):**
 
 ```javascript
-newRelativeDateFilter('<date-dataset-identifier>', 'GDC.time.date', -7, -1);
+newRelativeDateFilter("<date-dataset-identifier>", "GDC.time.date", -7, -1);
 ```
 
 **Last 12 months including the current month**
 
 ```javascript
-newRelativeDateFilter('<date-dataset-identifier>', 'GDC.time.month', -11, 0);
+newRelativeDateFilter("<date-dataset-identifier>", "GDC.time.month", -11, 0);
 ```
 
 **Last quarter only**
 
 ```javascript
-newRelativeDateFilter('<date-dataset-identifier>', 'GDC.time.quarter', -1, -1);
+newRelativeDateFilter("<date-dataset-identifier>", "GDC.time.quarter", -1, -1);
 ```
 
 ## Filter by a measure value
@@ -166,12 +166,12 @@ where:
    pass an instance of measure and the factory will extract the localIdentifier for you.
 
 -  `operator` is one of the following:
-    * `'GREATER_THAN'`: The measure value is greater than `value`.
-    * `'GREATER_THAN_OR_EQUAL_TO'`: The measure value is greater than `value` or equal to `value`.
-    * `'LESS_THAN'`: The measure value is less than `value`.
-    * `'LESS_THAN_OR_EQUAL_TO'`: The measure value is less than `value` or equal to `value`.
-    * `'EQUAL_TO'`: The measure value is equal to `value`.
-    * `'NOT_EQUAL_TO'`: The measure value is not equal to `value`.
+    * `"GREATER_THAN"`: The measure value is greater than `value`.
+    * `"GREATER_THAN_OR_EQUAL_TO"`: The measure value is greater than `value` or equal to `value`.
+    * `"LESS_THAN"`: The measure value is less than `value`.
+    * `"LESS_THAN_OR_EQUAL_TO"`: The measure value is less than `value` or equal to `value`.
+    * `"EQUAL_TO"`: The measure value is equal to `value`.
+    * `"NOT_EQUAL_TO"`: The measure value is not equal to `value`.
 
 -  `value` is the measure value to filter against.
 -  `treatNullValuesAs` is optional; by default, any filter condition filters out null values. If you want a filter
@@ -193,8 +193,8 @@ where:
    pass an instance of the measure, and the factory will extract `localIdentifier` for you.
 
 -  `operator` is one of the following:
-    * `'BETWEEN'`: The measure value is between the `from` and `to` values (including the boundaries).
-    * `'NOT_BETWEEN'`: The measure value is not between the `from` and `to` values (excluding the boundaries).
+    * `"BETWEEN"`: The measure value is between the `from` and `to` values (including the boundaries).
+    * `"NOT_BETWEEN"`: The measure value is not between the `from` and `to` values (excluding the boundaries).
 
 -  `from` is the start boundary.
 -  `to` is the end boundary.
@@ -257,8 +257,8 @@ You can specify `localIdentifier` explicitly or pass an instance of the attribut
 This parameter is optional. If it is not specified, the ranking behaves as if you would enter the list of all attributes in the visualization.
 
 -  `operator` is one of the following:
-    * `'TOP'` returns records with the highest values of the filtered measure for the granularity specified by the filter attributes.
-    * `'BOTTOM'` returns records with the lowest values of the filtered measure for the granularity specified by the filter attributes.
+    * `"TOP"` returns records with the highest values of the filtered measure for the granularity specified by the filter attributes.
+    * `"BOTTOM"` returns records with the lowest values of the filtered measure for the granularity specified by the filter attributes.
 
 -  `value` is the number of the ranked records to return. The number must be a positive integer (1, 2, 3, ...).
 
@@ -284,7 +284,7 @@ import { Ldm } from "./ldm";
 
 const californiaSales = modifySimpleMeasure(
                             Ldm.$TotalSales,
-                            m => m.filters(newPositiveAttributeFilter(Ldm.StateName, ['California'])).alias('California Sales')
+                            m => m.filters(newPositiveAttributeFilter(Ldm.StateName, ["California"])).alias("California Sales")
                         );
 
 const style = { height: 300 };
@@ -301,14 +301,14 @@ const style = { height: 300 };
 ### InsightView component filter
 
 ```jsx
-import '@gooddata/sdk-ui-ext/styles/css/main.css';
-import { InsightView } from '@gooddata/sdk-ui-ext';
+import "@gooddata/sdk-ui-ext/styles/css/main.css";
+import { InsightView } from "@gooddata/sdk-ui-ext";
 import { newPositiveAttributeFilter } from "@gooddata/sdk-model";
 import { Ldm } from "./ldm";
 
 const filters = [
-    newPositiveAttributeFilter(Ldm.StateName, ['California']),
-    newPositiveAttributeFilter(Ldm.IsKidsItem, ['true'])
+    newPositiveAttributeFilter(Ldm.StateName, ["California"]),
+    newPositiveAttributeFilter(Ldm.IsKidsItem, ["true"])
 ];
 
 <div style={{ height: 400, width: 600 }}>
@@ -339,7 +339,7 @@ const style = { height: 300 };
         filters={[
             newNegativeAttributeFilter(
                 Ldm.StateName,
-                { uris: ['/gdc/md/xms7ga4tf3g3nzucd8380o2bev8oeknp/obj/2210/elements?id=6340116'] })
+                { uris: ["/gdc/md/xms7ga4tf3g3nzucd8380o2bev8oeknp/obj/2210/elements?id=6340116"] })
         ]}
     />
 </div>

--- a/docs/30_tips__sso.md
+++ b/docs/30_tips__sso.md
@@ -29,13 +29,13 @@ Setting up authentication depends on what type of SSO is implemented on your sit
 * If you use the [GoodData PGP SSO](https://help.gooddata.com/display/doc/GoodData+PGP+Single+Sign-On) implementation, you can use the `loginSSO` method from [`@gooddata/api-client-bear`](https://github.com/gooddata/gooddata-ui-sdk/tree/master/libs/api-client-bear). Note that although this method requires a mandatory parameter of `targetUrl`, this parameter is used very rarely in the context of GoodData.UI, because in a typical scenario there is no need to redirect a user to any GoodData URL. But as this parameter is mandatory, set it to an arbitrary relative URL (for example, `/`).
 
     ```javascript
-    import { factory } from '@gooddata/api-client-bear';
+    import { factory } from "@gooddata/api-client-bear";
 
-    const domain = 'https://my.app.com/';
+    const domain = "https://my.app.com/";
     const sdk = factory({ domain });
-    const encryptedClaims = 'your-generated-encrypted-claims';
-    const ssoProvider = 'your-sso-provider-name';
-    const targetUrl = 'your-target-url'; // set to an arbitrary relative URL
+    const encryptedClaims = "your-generated-encrypted-claims";
+    const ssoProvider = "your-sso-provider-name";
+    const targetUrl = "your-target-url"; // set to an arbitrary relative URL
 
     sdk.user
       .loginSso(encryptedClaims, ssoProvider, targetUrl)
@@ -68,10 +68,10 @@ Setting up authentication depends on what type of SSO is implemented on your sit
     The following is an example of login code:
 
     ```javascript
-    import sdk from '@gooddata/api-client-bear';
-    import qs from 'qs';
+    import sdk from "@gooddata/api-client-bear";
+    import qs from "qs";
 
-    const relayState = 'https://my.app.com/';
+    const relayState = "https://my.app.com/";
 
     sdk.xhr
       .get(`/gdc/account/samlrequest?${qs.stringify({ relayState })}`)
@@ -96,9 +96,9 @@ This is how authentication process works:
 2. Your application verifies whether the user is logged in. For example:
 
     ```javascript
-    import { factory } from '@gooddata/api-client-bear';
+    import { factory } from "@gooddata/api-client-bear";
 
-    const domain = 'https://my.app.com/';
+    const domain = "https://my.app.com/";
     const sdk = factory({ domain });
 
     sdk.user.isLoggedIn().then((isLogged) => {

--- a/docs/30_tips__use_angular_1.x.md
+++ b/docs/30_tips__use_angular_1.x.md
@@ -14,61 +14,61 @@ You can use the visual components in your Angular 1._x_ app. There are several
 
 2. Inject `react` \(`ngreact`\) as a dependency into your Angular module:
     ```javascript
-    require('ngreact');
+    require("ngreact");
 
-    angular.module('app', ['react']);
+    angular.module("app", ["react"]);
     ```
 
 3. In the JS file, review the following snippet.
    This snippet uses data from example project and represents the bar chart from this project. For testing purposes, you can use this snippet as is.
    When you start creating your own visualization, you can update this snippet according to what data you have in your project \(measures, attributes, and so on\), and what visualization you want to create \(for example, a table or a KPI\).
     ```javascript
-    import angular from 'angular';
-    import 'ngreact';
-    import './styles/app.scss';
-    
-    import { BarChart } from '@gooddata/react-components'; // Importing the required components
-    
-    angular.module('gdcAngularApp', ['react']) // Injecting ngReact
-    .controller('MainPageController', function() {
+    import angular from "angular";
+    import "ngreact";
+    import "./styles/app.scss";
+
+    import { BarChart } from "@gooddata/react-components"; // Importing the required components
+
+    angular.module("gdcAngularApp", ["react"]) // Injecting ngReact
+    .controller("MainPageController", function() {
         this.barChartProps = {
           afm: {
             measures: [
               {
-                localIdentifier: 'CustomMeasureID',
+                localIdentifier: "CustomMeasureID",
                 definition: {
                   measure: {
                     item: {
-                      identifier: 'acKjadJIgZUN'
+                      identifier: "acKjadJIgZUN"
                     }
                   }
                 },
-                alias: '# of Activities'
+                alias: "# of Activities"
               }
             ],
             attributes: [
               {
-                localIdentifier: 'a1',
+                localIdentifier: "a1",
                 displayForm: {
-                  identifier: 'label.activity.type'
+                  identifier: "label.activity.type"
                 }
               }
             ]
           },
-          projectId: 'la84vcyhrq8jwbu4wpipw66q2sqeb923',
+          projectId: "la84vcyhrq8jwbu4wpipw66q2sqeb923",
           resultSpec: {}
       };
     })
     ```
 
 4. Register a React component to use in Angular.
- 
+
    To do so, use _one_ of the following methods:
    * Register the React component using the
      [react-component directive](https://github.com/ngReact/ngReact#the-react-component-directive).
      1. In JS file, add the following line under the snippet from Step 3:
         ```javascript
-        .value('BarChart', BarChart);
+        .value("BarChart", BarChart);
         ```
      2. In the HTML file, insert the following snippet:
         ```javascript
@@ -84,8 +84,8 @@ You can use the visual components in your Angular 1._x_ app. There are several
      [reactDirective service](https://github.com/ngReact/ngReact#the-reactdirective-service).
      1. In JS file, add the following lines under the snippet from Step 3:
         ```javascript
-        .directive('barChart', function(reactDirective) {
-          return reactDirective(BarChart, ['afm', 'resultSpec', 'projectId']);
+        .directive("barChart", function(reactDirective) {
+          return reactDirective(BarChart, ["afm", "resultSpec", "projectId"]);
         });
         ```
 

--- a/docs/30_tips__use_angular_2.x.md
+++ b/docs/30_tips__use_angular_2.x.md
@@ -76,10 +76,10 @@ The following examples are using a single KPI component:
 **kpi.component.ts**:
 
 ```javascript
-import * as React from 'react';
-import * as ReactDOM from 'react-dom';
-import * as uuid from 'uuid';
-import * as invariant from 'invariant';
+import * as React from "react";
+import * as ReactDOM from "react-dom";
+import * as uuid from "uuid";
+import * as invariant from "invariant";
 
 import {
   Component,
@@ -88,11 +88,11 @@ import {
   OnDestroy,
   OnChanges,
   AfterViewInit,
-} from '@angular/core';
-import { Kpi, IKpiProps, newMeasure } from '@gooddata/sdk-ui-all';
+} from "@angular/core";
+import { Kpi, IKpiProps, newMeasure } from "@gooddata/sdk-ui-all";
 import bearFactory, {
   ContextDeferredAuthProvider,
-} from '@gooddata/sdk-backend-bear';
+} from "@gooddata/sdk-backend-bear";
 
 // Just for illustration, you would probably create this once in your app and import here
 const backend = bearFactory().withAuthentication(
@@ -100,8 +100,8 @@ const backend = bearFactory().withAuthentication(
 );
 
 @Component({
-  selector: 'app-kpi',
-  template: '<span [id]="rootDomID"></span>',
+  selector: "app-kpi",
+  template: "<span [id]="rootDomID"></span>",
 })
 export class KpiComponent
   implements OnInit, OnDestroy, OnChanges, AfterViewInit {
@@ -116,7 +116,7 @@ export class KpiComponent
 
   protected getRootDomNode() {
     const node = document.getElementById(this.rootDomID);
-    invariant(node, `Node '${this.rootDomID} not found!`);
+    invariant(node, `Node '${this.rootDomID}' not found!`);
     return node;
   }
 
@@ -180,13 +180,13 @@ If you want to render some charts, do the following:
     ```javascript
     ...
 
-    import { ColumnChart } from '@gooddata/sdk-ui-all';
+    import { ColumnChart } from "@gooddata/sdk-ui-all";
 
     ...
 
     @Component({
-      selector: 'app-column-chart',
-      template: '<div style="height: 300px" [id]="rootDomID"></div>'
+      selector: "app-column-chart",
+      template: "<div style="height: 300px" [id]="rootDomID"></div>"
     })
 
     ...

--- a/docs/30_tips__use_different_domains.md
+++ b/docs/30_tips__use_different_domains.md
@@ -12,22 +12,22 @@ Every GoodData.UI instance is connected to a specific domain. To use multiple do
 ## Example
 
 ```jsx
-import React, { PureComponent } from 'react';
-import bearFactory from '@gooddata/sdk-backend-bear';
-import { InsightView } from '@gooddata/sdk-ui-ext';
- 
- 
+import React, { PureComponent } from "react";
+import bearFactory from "@gooddata/sdk-backend-bear";
+import { InsightView } from "@gooddata/sdk-ui-ext";
+
+
 export default class SampleVisualizations extends PureComponent {
     constructor(props) {
         super(props);
-         
-        const domain1 = 'my-custom-domain.com';
+
+        const domain1 = "my-custom-domain.com";
         this.backend1 = bearFactory({ hostname: domain1 });
-     
-        const domain2 = 'another-custom-domain.com';
+
+        const domain2 = "another-custom-domain.com";
         this.backend2 = bearFactory({ hostname: domain2 });
     }
- 
+
     render() {
         return (
             <div>

--- a/docs/30_tips__use_with_vanilla_js.md
+++ b/docs/30_tips__use_with_vanilla_js.md
@@ -133,12 +133,12 @@ GDRC.ReactContentRenderer.render(
    GDRC.Kpi,
    // props to be passed to the Kpi component
    {
-     projectId: 'kf0vsjlf9mll0osg6hmtppgm1nkjsi9r',
-     measure: 'aqyCuRZbheEx',
-     format: '#,##0'
+     projectId: "kf0vsjlf9mll0osg6hmtppgm1nkjsi9r",
+     measure: "aqyCuRZbheEx",
+     format: "#,##0"
    },
    // target DOM node
-   document.getElementById('kpi')
+   document.getElementById("kpi")
  );
 }
 

--- a/docs/50_custom__component.md
+++ b/docs/50_custom__component.md
@@ -20,7 +20,7 @@ You specify the input data by using the component parameters. Then, the executio
 | onLoadingChanged | false | function |
 | onLoadingFinish | false | function |
 
-* If you specify a function in the `onError` parameter, this function will be called in case of an error. It is always executed after `onLoadingChanged`. The first parameter is an error object: `{ status: ErrorStates, error?: string }`. Status can be one of the following \(use `import { ErrorStates } from '@gooddata/react-components'`\):
+* If you specify a function in the `onError` parameter, this function will be called in case of an error. It is always executed after `onLoadingChanged`. The first parameter is an error object: `{ status: ErrorStates, error?: string }`. Status can be one of the following \(use `import { ErrorStates } from "@gooddata/react-components"`\):
 
   * `ErrorStates.DATA_TOO_LARGE_TO_COMPUTE`
   * `ErrorStates.HTTP_BAD_REQUEST`
@@ -30,14 +30,14 @@ You specify the input data by using the component parameters. Then, the executio
 
 * If you specify a function in the `onLoadingFinish` parameter, this function will be called every time a data load finishes successfully, and it will get the execution result object `{ result }` as a parameter. It is always executed after `onLoadingChanged`. `onLoadingFinish` is *not* called when an execution finishes with an error.
 
-* Empty execution results can be found by an empty data property in the result. To check if the result is empty, use `import { isEmptyResult } from '@gooddata/react-components'`.
+* Empty execution results can be found by an empty data property in the result. To check if the result is empty, use `import { isEmptyResult } from "@gooddata/react-components"`.
 
 ## Example
 
 The following example shows the function specified as a child in the Execution component that displays the execution output on the console.
 
 ```javascript
-import { Execute, isEmptyResult } from '@gooddata/react-components';
+import { Execute, isEmptyResult } from "@gooddata/react-components";
 
 <Execute afm={<afm>} projectId={<project-id>} onLoadingChanged={e=>{}} onLoadingFinish={e=>{}} onError={e=>{}}>
     {
@@ -64,7 +64,7 @@ The execution result is a data structure that is returned from the GET command o
 ```javascript
 {
   data: [
-    [ '58656.37', '33098.97', '123633.07', '75019.19' ],
+    [ "58656.37", "33098.97", "123633.07", "75019.19" ],
     ...
   ],
   paging: {
@@ -77,8 +77,8 @@ The execution result is a data structure that is returned from the GET command o
       [
         {
           attributeHeaderItem: {
-            name: 'Apparel',
-            uri: '/gdc/md/k790ohq1d8xcas9oipmwfs544tqkepku/obj/15399/elements?id=1200'
+            name: "Apparel",
+            uri: "/gdc/md/k790ohq1d8xcas9oipmwfs544tqkepku/obj/15399/elements?id=1200"
           }
         },
         ...
@@ -88,8 +88,8 @@ The execution result is a data structure that is returned from the GET command o
       [
         {
           attributeHeaderItem: {
-            name: 'Midwest',
-            uri: '/gdc/md/k790ohq1d8xcas9oipmwfs544tqkepku/obj/15386/elements?id=2052'
+            name: "Midwest",
+            uri: "/gdc/md/k790ohq1d8xcas9oipmwfs544tqkepku/obj/15386/elements?id=2052"
           }
         },
         ...
@@ -97,7 +97,7 @@ The execution result is a data structure that is returned from the GET command o
       [
         {
           measureHeaderItem: {
-            name: 'Sum of Orders',
+            name: "Sum of Orders",
             order: 0
           }
         },
@@ -137,12 +137,12 @@ The `headerItems` array lists all header items \(also called elements\) in a thr
 The following example shows how to handle the `onLoadingChanged` and `onError` callbacks within a custom component. The React `key` prop is used to force remounting of the Execute component on retry. The example fails randomly 50% of the time to showcase handling of error states.
 
 ```javascript
-import React, { Component } from 'react';
-import { Execute, isEmptyResult } from '@gooddata/react-components';
+import React, { Component } from "react";
+import { Execute, isEmptyResult } from "@gooddata/react-components";
 
-import { totalSalesIdentifier, projectId } from '../utils/fixtures';
-import { Loading } from './utils/Loading';
-import { Error } from './utils/Error';
+import { totalSalesIdentifier, projectId } from "../utils/fixtures";
+import { Loading } from "./utils/Loading";
+import { Error } from "./utils/Error";
 
 export class ExecuteExample extends Component {
     constructor(props) {
@@ -162,7 +162,7 @@ export class ExecuteExample extends Component {
 
     onLoadingChanged({ isLoading }) {
         // eslint-disable-next-line no-console
-        console.log('isLoading', isLoading);
+        console.log("isLoading", isLoading);
         // onLoadingChanged must reset the error so that we are not in error during loading
         // onError is run after onLoadingChanged so we do not have to worry about an overriding current error
         this.setState({
@@ -173,7 +173,7 @@ export class ExecuteExample extends Component {
 
     onError(error) {
         // eslint-disable-next-line no-console
-        console.log('onError', error);
+        console.log("onError", error);
         this.setState({
             error
         });
@@ -181,7 +181,7 @@ export class ExecuteExample extends Component {
 
     retry() {
         // eslint-disable-next-line no-console
-        console.log('retry');
+        console.log("retry");
         // We need to track executionNumber so that we can remount the Execute component
         // To showcase error states, here we also decide if the next execution will fail or not
         this.setState({
@@ -215,7 +215,7 @@ export class ExecuteExample extends Component {
                 `}</style>
                 <p className="kpi s-execute-kpi">{result.executionResult.data[0]}</p>
                 <p>Full execution response and result as JSON:</p>
-                <pre>{JSON.stringify({ result, isLoading, error }, null, '  ')}</pre>
+                <pre>{JSON.stringify({ result, isLoading, error }, null, "  ")}</pre>
             </div>
         );
     }
@@ -225,7 +225,7 @@ export class ExecuteExample extends Component {
         const afm = {
             measures: [
                 {
-                    localIdentifier: 'measure',
+                    localIdentifier: "measure",
                     definition: {
                         measure: {
                             item: {

--- a/docs/50_custom__create_new_visualization.md
+++ b/docs/50_custom__create_new_visualization.md
@@ -1,5 +1,5 @@
 ---
-title: Create a Custom Visualization 
+title: Create a Custom Visualization
 sidebar_label: Create a Custom Visualization
 copyright: (C) 2007-2018 GoodData Corporation
 id: create_new_visualization
@@ -11,14 +11,14 @@ Your component code must be wrapped within the Execute component. This component
 the data to render and then access the results:
 
 ```jsx
-import { Execute } from '@gooddata/sdk-ui';
+import { Execute } from "@gooddata/sdk-ui";
 
 function CustomVisualization() {
     return (
-        <Execute 
-            seriesBy={measuresAndAttributes} 
-            slicesBy={attributes} 
-            onLoadingChanged={e=>{}} 
+        <Execute
+            seriesBy={measuresAndAttributes}
+            slicesBy={attributes}
+            onLoadingChanged={e=>{}}
             onError={e=>{}}>
             {
                 (execution) => {
@@ -28,10 +28,10 @@ function CustomVisualization() {
                     } else if (error) {
                         return (<div>There was an error</div>);
                     }
-                    
-                    // access result by slices (rows); 
+
+                    // access result by slices (rows);
                     const slices = result.data().slices().toArray();
-        
+
                     return (
                         <div>
                             {slices.map((slice, idx) => {
@@ -52,18 +52,18 @@ function CustomVisualization() {
 
 ## Data series and data slices
 
-The concept of data series and data slices used by the Execute component is best explained on a couple of real-life examples. 
+The concept of data series and data slices used by the Execute component is best explained on a couple of real-life examples.
 
 ### Tabular data
 
-Imagine that you want to create a custom table component. This component should show one row for each value of the 
+Imagine that you want to create a custom table component. This component should show one row for each value of the
 attribute `A1`. In each row, there should be two columns, one for the measure `M1` and one for the measure `M2`.
 
 In this scenario, the data series are the two measures `M1` and `M2`, and the slices are defined from the attribute `A1`.
 
 Now, imagine that this typical table must become more dynamic. For each value of th eattribute `A2`, the table must include two columns: one for each measure, `M1` and `M2`.
 
-In this scenario, the data series are measures `M1` and `M2`, **scoped** to values of the attribute `A2`. And on top of it, 
+In this scenario, the data series are measures `M1` and `M2`, **scoped** to values of the attribute `A2`. And on top of it,
 these columns are sliced by values of the attribute `A1`.
 
 ### Scalars
@@ -75,18 +75,18 @@ In this scenario, the data series are the measures `M1`, `M2`, and `M3`, and the
 
 ## Working with the results
 
-Once the Execute component reads the results from the Analytical Backend, it will pass the result to your custom function. 
+Once the Execute component reads the results from the Analytical Backend, it will pass the result to your custom function.
 The instance of the result contains several methods for convenient data access.
 
   -  You can access the result by data series by calling the `result.data().series()`.
   -  You can access the result by data slices by calling the `result.data().slices()`.
-  -  These methods return a collection of series and slices respectivelly. 
+  -  These methods return a collection of series and slices respectivelly.
   -  You can either iterate the items from the collection using the `for-of` loop or transform it to an array and then use the typical array mapping and manipulation functions of JavaScript.
   -  For each series or slice item, you can then iterate the available data points.
      -  Iterating data points for a series gives you one data point per slice.
      -  Iterating data points for a slice gives you one data point per series.
   -  Each data point contains both data and all available metadata (series descriptor, slice descriptor). You can
      access either the raw data or formatted data.
-     
+
 **NOTE**: While the result instance exposes the raw results from the backend, we strongly discourage you from accessing
 the raw data.

--- a/docs/50_custom__execution.md
+++ b/docs/50_custom__execution.md
@@ -5,7 +5,7 @@ copyright: (C) 2007-2018 GoodData Corporation
 id: afm
 ---
 
-An **execution** is a combination of attributes, measures, and filters that describes what data you want to calculate. 
+An **execution** is a combination of attributes, measures, and filters that describes what data you want to calculate.
 
 **NOTE:** A measure contains numeric data (for example, revenue). Measures can be sliced by selected attributes (for example, city, date in years, or both) and filtered by attribute values or date constraints. For more information, see the [main concepts](01_intro__platform_intro.md#main-concepts).
 
@@ -28,7 +28,7 @@ const firstPage = await result.readWindow([0, 0], [10, 10]);
 const allData = await result.readAll();
 ```
 
-In the above example, the code starts an execution in the workspace with `project_id`. It specifies execution for the `measuresAndAttributes` array filtered by the `filters` array. 
+In the above example, the code starts an execution in the workspace with `project_id`. It specifies execution for the `measuresAndAttributes` array filtered by the `filters` array.
 
 On top of that, it configures `sorting` of the result data and how to lay out the data into `dimensions`.
 
@@ -37,19 +37,19 @@ and dimensionality setup, see [Specify the Result Structure](50_custom__result.m
 
 ## Attribute
 
-Each attribute is defined by its `displayForm` that will be used to slice the data. You can create an attribute 
+Each attribute is defined by its `displayForm` that will be used to slice the data. You can create an attribute
 definition using the following factory function:
 
 ```javascript
-    const attribute = newAttribute('<attribute-displayForm-identifier>');
+    const attribute = newAttribute("<attribute-displayForm-identifier>");
 ```
 
-Each attribute requires a `localIdentifier` that you can use to reference the attribute in the scope of the execution (for instance, when specifying sorting). The factory function assigns a stable `localIdentifier` for you. 
+Each attribute requires a `localIdentifier` that you can use to reference the attribute in the scope of the execution (for instance, when specifying sorting). The factory function assigns a stable `localIdentifier` for you.
 
 You can optionally override the `localIdentifier` and also the title of the attribute in the factory function call:
 
 ```javascript
-    const attribute = newAttribute('<attribute-displayForm-identifier>', m => m.localId('myLocalId').alias('My Attribute'));
+    const attribute = newAttribute("<attribute-displayForm-identifier>", m => m.localId("myLocalId").alias("My Attribute"));
 ```
 
 All attributes are defined using their `displayForm` identifiers. This assures that you application can work on top of
@@ -85,26 +85,26 @@ Each measure created from a fact can specify `aggregation` of data. Aggregation 
 
 | Type | Description |
 | :--- | :--- |
-| `'sum'` | Returns a sum of all numbers in the set |
-| `'count'` | Counts unique values of a selected attribute in a given dataset determined by the second attribute parameter  (ignores the measure's `format` value and uses the default value `#,##0` instead) |
-| `'avg'` | Returns the average value of all numbers in the set; null values are ignored |
-| `'min'` | Returns the minimum value of all numbers in the set |
-| `'max'` | Returns the maximum value of all numbers in the set |
-| `'median'` | Counts the statistical median - an order statistic that gives the "middle" value of a sample. If the "middle" falls between two values, the function returns average of the two middle values. Null values are ignored. |
-| `'runsum'` | Returns a sum of numbers increased by the sum from the previous value \(accumulating a sum incrementally\) |
+| `"sum"` | Returns a sum of all numbers in the set |
+| `"count"` | Counts unique values of a selected attribute in a given dataset determined by the second attribute parameter  (ignores the measure's `format` value and uses the default value `#,##0` instead) |
+| `"avg"` | Returns the average value of all numbers in the set; null values are ignored |
+| `"min"` | Returns the minimum value of all numbers in the set |
+| `"max"` | Returns the maximum value of all numbers in the set |
+| `"median"` | Counts the statistical median - an order statistic that gives the "middle" value of a sample. If the "middle" falls between two values, the function returns average of the two middle values. Null values are ignored. |
+| `"runsum"` | Returns a sum of numbers increased by the sum from the previous value \(accumulating a sum incrementally\) |
 
 [catalog-export](02_start__catalog_export.md) generates measure definitions for all available aggregations for you.
 
 ### Filters in a measure definition
 
-Each measure can be filtered by attribute filters. Filters are represented by an array of `IFilter` objects. 
+Each measure can be filtered by attribute filters. Filters are represented by an array of `IFilter` objects.
 
 Only one filter of the `DateFilter` type is allowed in the measure's filter definition.
 
-* When both the measure filter of the `DateFilter` type and the global filter of the `DateFilter` type are set with 
-  the **same** date dimension, the measure date filter overrides the global date filter for this measure 
+* When both the measure filter of the `DateFilter` type and the global filter of the `DateFilter` type are set with
+  the **same** date dimension, the measure date filter overrides the global date filter for this measure
   \(global date filters are still applied to other measures that do not have a measure date filter defined\).
-* When the measure filter of the `DateFilter` type and the global filter of the `DateFilter` type are set 
+* When the measure filter of the `DateFilter` type and the global filter of the `DateFilter` type are set
   with **different** date dimensions, the filters are interpreted as an intersection of those filters (`f1 AND f2`).
 
 ### Show a measure as a percentage
@@ -129,10 +129,10 @@ When the property is enabled, the measure's `format` value is ignored. The defau
 
 ### Compare a measure over time
 
-To compare a measure over time, add one of the supported measure types described 
+To compare a measure over time, add one of the supported measure types described
 in [Time Over Time Comparison](20_misc__time_over_time_comparison.md) to execution.
 
 ### Calculated measures
 
-To create arithmetic measures (for example, when you want to subtract a measure from another measure), 
+To create arithmetic measures (for example, when you want to subtract a measure from another measure),
 add arithmetic measures described in [Arithmetic Measure](20_misc__arithmetic_measure.md) to the execution items. Then, add all the arithmetic measure operands to the execution itself.

--- a/docs/50_custom__result.md
+++ b/docs/50_custom__result.md
@@ -11,7 +11,7 @@ should be cross-tabulated: how the backend should lay out the data into dimensio
 ## Dimensions
 
 The dimensions communicate to the Analytical Backend how to organize data into arrays. Imagine an attribute in columns vs. rows.
- 
+
 Each dimension specifies **items**. These items could be attributes' `localIdentifier`'s or a special `measureGroup` identifier.
 The `measureGroup` identifier tells the executor to place all measures from the execution into the dimension.
 
@@ -70,12 +70,12 @@ execution()
     .forItems([Ldm.LocationState, Ldm.$FranchiseFees])
     .withDimensions([newDimension([Ldm.LocationState, MeasureGroupIdentifier])]);
 
-{  
+{
 data: [ 32000, 41000, 77000 ]
 }
 ```
 
-#### Execution with two measures and one attribute 
+#### Execution with two measures and one attribute
 
 Use case: a simple table; row per attribute value, measures are in columns
 
@@ -188,7 +188,7 @@ const executionResult = await execution().forItems(...).execute();
 const dataView = await executionResult.readAll();
 
 const facade = DataViewFacade.for(dataView);
-``` 
+```
 
 ## Dimensions: Quick reference
 
@@ -201,32 +201,32 @@ const facade = DataViewFacade.for(dataView);
 </tr>
 <tr>
 <td class="confluenceTd">One measure<br>One attribute (A)</td>
-<td class="confluenceTd">[ 'A', 'measureGroup' ]</td>
+<td class="confluenceTd">[ "A", "measureGroup" ]</td>
 <td class="confluenceTd"><pre><code>        A1    A2    A3     ← elements of attribute A<br>data: [ ... , ... , ... ]&nbsp; ←&nbsp;values of the measure</code></pre></td>
 </tr>
 <tr>
 <td class="confluenceTd">Two measures (M1, M2)</td>
-<td class="confluenceTd">[ 'measureGroup' ]</td>
+<td class="confluenceTd">[ "measureGroup" ]</td>
 <td class="confluenceTd"><pre><code>        M1    M2     ← elements of measureGroup<br>data: [ ... , ... ]</code></pre></td>
 </tr>
 <tr>
 <td class="confluenceTd">Two measures (M1, M2)<br>One attribute (A)</td>
-<td class="confluenceTd">[ 'A', 'measureGroup' ]</td>
+<td class="confluenceTd">[ "A", "measureGroup" ]</td>
 <td class="confluenceTd"><pre><code>        A1-M1  A1-M2  A2-M1  A2-M2   ← a cartesian product of<br>data: [ .... , .... , .... , .... ]    elements from A and <br>                                       measureGroup</code></pre></td>
 </tr>
 <tr>
 <td class="confluenceTd">Empty first dimension<br>Two measures (M1, M2)<br>One attribute (A)</td>
-<td class="confluenceTd">[ ],<br> [ 'A', 'measureGroup' ]</td>
+<td class="confluenceTd">[ ],<br> [ "A", "measureGroup" ]</td>
 <td class="confluenceTd"><pre><code>data: [<br>    A1    A2    A3    ← the same as above<br>  [ ... , ... , ... ]<br>]</code></pre></td>
 </tr>
 <tr>
 <td class="confluenceTd">Two measures (M1, M2)</span> <br> <span>One attribute (A)<br> <br>// typical for a viewBy chart</td>
-<td class="confluenceTd">[ 'A' ],<br>[ 'measureGroup' ]<br></td>
+<td class="confluenceTd">[ "A" ],<br>[ "measureGroup" ]<br></td>
 <td class="confluenceTd"><pre><code>data: [                  // it can be understood as data[A][M]<br>    M1    M2                aka first dimension = elements of A<br>  [ ... , ... ],  ← A1      and second = elems of measureGroup<br>  [ ... , ... ]   ← A2<br>] </code></pre></td>
 </tr>
 <tr>
 <td class="confluenceTd">Two attributes (A, B)<br>One measure (M1)<br> <br>// typical for a stackBy chart</td>
-<td class="confluenceTd">[ 'A' ],<br>[ 'B', 'measureGroup' ]</td>
+<td class="confluenceTd">[ "A" ],<br>[ "B", "measureGroup" ]</td>
 <td class="confluenceTd"><pre><code>data: [                  // notice it doesn't matter in which<br>    B1-M1  B2-M1            dimension the measureGroup is<br>  [ .... , .... ],  ← A1    placed (as it has only one measure)<br>  [ .... , .... ]   ← A2<br>] </code></pre></td>
 </tr>
 </tbody>

--- a/docs/afm_components.md
+++ b/docs/afm_components.md
@@ -25,8 +25,8 @@ The AFM components use the [AFM](50_custom__execution.md) property instead of sp
 ### Structure
 
 ```javascript
-import '@gooddata/react-components/styles/css/main.css';
-import { AfmComponents } from '@gooddata/react-components';
+import "@gooddata/react-components/styles/css/main.css";
+import { AfmComponents } from "@gooddata/react-components";
 
 const { BarChart } = AfmComponents; // replace BarChart with ColumnChart, LineChart, or PieChart whenever needed
 
@@ -42,8 +42,8 @@ const { BarChart } = AfmComponents; // replace BarChart with ColumnChart, LineCh
 ### Example
 
 ```javascript
-import '@gooddata/react-components/styles/css/main.css';
-import { AfmComponents } from '@gooddata/react-components';
+import "@gooddata/react-components/styles/css/main.css";
+import { AfmComponents } from "@gooddata/react-components";
 
 const { BarChart } = AfmComponents;
 
@@ -51,22 +51,22 @@ const { BarChart } = AfmComponents;
     afm={{
         measures: [
             {
-                localIdentifier: 'CustomMeasureID',
+                localIdentifier: "CustomMeasureID",
                 definition: {
                     measure: {
                         item: {
-                            identifier: '<measure-identifier>' // can be referenced from the exported catalog
+                            identifier: "<measure-identifier>" // can be referenced from the exported catalog
                         }
                     }
                 },
-                alias: 'My Measure'
+                alias: "My Measure"
             }
         ],
         attributes: [
             {
-                localIdentifier: 'a1',
+                localIdentifier: "a1",
                 displayForm: {
-                    identifier: '<attribute-display-form-identifier>'
+                    identifier: "<attribute-display-form-identifier>"
                 }
             }
         ]
@@ -90,8 +90,8 @@ const { BarChart } = AfmComponents;
 ### Structure
 
 ```javascript
-import '@gooddata/react-components/styles/css/main.css';
-import { AfmComponents } from '@gooddata/react-components';
+import "@gooddata/react-components/styles/css/main.css";
+import { AfmComponents } from "@gooddata/react-components";
 
 const { Table } = AfmComponents;
 
@@ -106,8 +106,8 @@ const { Table } = AfmComponents;
 ### Example
 
 ```javascript
-import '@gooddata/react-components/styles/css/main.css';
-import { AfmComponents } from '@gooddata/react-components';
+import "@gooddata/react-components/styles/css/main.css";
+import { AfmComponents } from "@gooddata/react-components";
 
 const { Table } = AfmComponents;
 
@@ -115,22 +115,22 @@ const { Table } = AfmComponents;
     afm={{
         measures: [
             {
-                localIdentifier: 'CustomMeasureID',
+                localIdentifier: "CustomMeasureID",
                 definition: {
                     measure: {
                         item: {
-                            identifier: '<measure-identifier>' // can be referenced from the exported catalog
+                            identifier: "<measure-identifier>" // can be referenced from the exported catalog
                         }
                     }
                 },
-                alias: 'My Measure'
+                alias: "My Measure"
             }
         ],
         attributes: [
             {
-                localIdentifier: 'a1',
+                localIdentifier: "a1",
                 displayForm: {
-                    identifier: '<attribute-display-form-identifier>'
+                    identifier: "<attribute-display-form-identifier>"
                 }
             }
         ]

--- a/docs/breaking_changes_8.md
+++ b/docs/breaking_changes_8.md
@@ -7,7 +7,7 @@ id: breaking_changes_8
 
 ## Repackaging
 
-The consolidation of all GoodData.UI packages under one repository, the desire to simplify versioning, and the major architectural changes we had to undertake for Version 8.0 have led us to reworking of the GoodData.UI packaging. 
+The consolidation of all GoodData.UI packages under one repository, the desire to simplify versioning, and the major architectural changes we had to undertake for Version 8.0 have led us to reworking of the GoodData.UI packaging.
 
 Starting with Version 8.0, we have established new naming conventions. Therefore, the existing packages are reaching the end of their development line and will be switched to maintenance mode:
 
@@ -15,7 +15,7 @@ Starting with Version 8.0, we have established new naming conventions. Therefore
 * `@gooddata/gooddata-js`
 * `@gooddata/react-components`
 
-New packages are taking their place, all starting at Version 8.0. Unless this documentation states otherwise, the contents of the old packages are available in the respective new packages. 
+New packages are taking their place, all starting at Version 8.0. Unless this documentation states otherwise, the contents of the old packages are available in the respective new packages.
 
 To adopt this change,  modify dependencies in your `package.json` file and update imports in your code. Some packages had additional breaking changes and will require further modification.
 
@@ -30,10 +30,10 @@ Here is mapping between the packages:
     -  `@gooddata/sdk-ui-geo` contains components for the Geo Pushpin Chart component.
     -  `@gooddata/sdk-ui-pivot` contains the Pivot Table component.
     -  `@gooddata/sdk-ui-filters` contain all filtering components.
-    -  `@gooddata/sdk-ui-ext` contains components for embedding insights created by Analytical Designer. 
+    -  `@gooddata/sdk-ui-ext` contains components for embedding insights created by Analytical Designer.
 
 ## Styling Changes
-The only styling changes in Version 8.0 are those that were needed to reflect the repackaging as described in 
+The only styling changes in Version 8.0 are those that were needed to reflect the repackaging as described in
 [Repackaging](#repackaging). The new packages now have their own primary stylesheets.
 
 To adopt this change, import the stylesheets from the respective package:
@@ -42,10 +42,10 @@ To adopt this change, import the stylesheets from the respective package:
 -  `@gooddata/sdk-ui-pivot/styles/css/main.css`
 -  `@gooddata/sdk-ui-filters/styles/css/main.css`
 
-    This imports styles for all filter components. If you are not using all the filter components in your application, 
+    This imports styles for all filter components. If you are not using all the filter components in your application,
     import only the styles for the components that you use: `attributeFilter.css`, `dateFilter.css`, or `measureValueFilter.css`.
 
-Apart from these structural changes, the styles themselves remain the same and there are no breaking changes when it 
+Apart from these structural changes, the styles themselves remain the same and there are no breaking changes when it
 comes to classes.
 
 ## Removed Components
@@ -54,63 +54,63 @@ We have removed several components from Version 8.0. Each removed component has 
 
 ### DataLayer Infrastructure
 
-This infrastructure was available in `gooddata-js`. Its role was to wrap and simplify performing executions and to 
-work with data results. We have effectively superseded this infrastructure by the new Analytical Backend APIs. 
+This infrastructure was available in `gooddata-js`. Its role was to wrap and simplify performing executions and to
+work with data results. We have effectively superseded this infrastructure by the new Analytical Backend APIs.
 
-The Analytical Backend API section pertaining to workspaces has dedicated execution APIs. These APIs work with the 
-same concepts that were used in the data layer, and the functionality available through them is a superset of what 
-was available in DataLayer. They allow you to specify the custom execution and work with its results in an easier 
+The Analytical Backend API section pertaining to workspaces has dedicated execution APIs. These APIs work with the
+same concepts that were used in the data layer, and the functionality available through them is a superset of what
+was available in DataLayer. They allow you to specify the custom execution and work with its results in an easier
 and more convenient way.
 
 To adopt this change, switch to using the Analytical Backend APIs.
 
 For more information, see [Custom Executions](50_custom__execution.md).
 
-### AFM-driven Visualizations 
+### AFM-driven Visualizations
 
-We have removed all AFM-driven charts from GoodData.UI. These components had been officially deprecated for more 
-than a year and reached their end-of-life in September 2019. 
+We have removed all AFM-driven charts from GoodData.UI. These components had been officially deprecated for more
+than a year and reached their end-of-life in September 2019.
 
-For each removed AFM-driven component, GoodData.UI comes with non-AFM alternatives. The non-AFM components have a 
+For each removed AFM-driven component, GoodData.UI comes with non-AFM alternatives. The non-AFM components have a
 more friendly interface using which you can specify what the chart should render.
 
-To adopt this change, switch to the appropriate non-AFM components. For instance, if you were using the AfmBarChart 
-component, switch to the BarChart component. To learn more about how to construct the visualizations, see the official 
+To adopt this change, switch to the appropriate non-AFM components. For instance, if you were using the AfmBarChart
+component, switch to the BarChart component. To learn more about how to construct the visualizations, see the official
 documentation, live examples, or the code documentation.
 
-### Legacy Table Component 
-We have had the Pivot Table component since Version 7.0. Feature-wise, the Pivot Table component has all features of the legacy 
-Table component and adds more on top of them. The legacy Table component has already been phased out from 
+### Legacy Table Component
+We have had the Pivot Table component since Version 7.0. Feature-wise, the Pivot Table component has all features of the legacy
+Table component and adds more on top of them. The legacy Table component has already been phased out from
 Analytical Designer and KPI Dashboards. In Version 8.0, we have removed the Table component from GoodData.UI.
 
-To adopt this change, change all uses of the Table component to the Pivot Table component. To learn more about how to 
+To adopt this change, change all uses of the Table component to the Pivot Table component. To learn more about how to
 use the Pivot Table component, see [Pivot Table](10_vis__pivot_table_component.md).
 
 ### Visualization Component
-We have redesigned the way insights created in Analytical Designer are embedded into applications. In the new design, 
-the embedding uses the exact same components and code paths as Analytical Designer or KPI Dashboards. This was not the 
+We have redesigned the way insights created in Analytical Designer are embedded into applications. In the new design,
+the embedding uses the exact same components and code paths as Analytical Designer or KPI Dashboards. This was not the
 case before, which may have resulted in bugs and issues.
 
-Additionally, we have recognized that the term "Visualization" is fairly overloaded within GoodData.UI and have 
+Additionally, we have recognized that the term "Visualization" is fairly overloaded within GoodData.UI and have
 opted to also rename this component to "InsightView".
 
 To adopt this change, use the new InsightView component to embed insights created by Analytical Designer.
 
 ## Changes in Communication with the Backend
 
-In Version 7.0, GoodData.UI used the `@gooddata/gooddata-js` package (mainly, its API client) to communicate with 
-the backend. The instance of the API client, commonly named `sdk`, was set globally for the application or was passed 
+In Version 7.0, GoodData.UI used the `@gooddata/gooddata-js` package (mainly, its API client) to communicate with
+the backend. The instance of the API client, commonly named `sdk`, was set globally for the application or was passed
 directly via component props.
 
-With Version 8.0, we have introduced a new implementation-agnostic layer to communicate with the backend and to no 
+With Version 8.0, we have introduced a new implementation-agnostic layer to communicate with the backend and to no
 longer work directly with the API client. This has the following impact:
 
 * The application initialization logic has changed and now looks like this:
     ```javascript
-    import { bearFactory } from '@gooddata/sdk-backend-bear'
+    import { bearFactory } from "@gooddata/sdk-backend-bear"
 
     const backend =
-        bearFactory({ hostname: ""<yourDomain>"" })
+        bearFactory({ hostname: "<yourDomain>" })
         .withAuthentication(<authenticationProvider>);
     ```
 
@@ -122,87 +122,96 @@ longer work directly with the API client. This has the following impact:
 To adopt these changes, create the backend once and then do **one** of the following:
 
 * Export the constant and use it in all visualizations:
-    ```jsx<BarChart 
-    backend={backend}
-    workspace={“<yourWorkspace>”}
-    measures={[Ldm.Won]}
-    viewBy={[Ldm.Product]} />
+
+    ```jsx
+    import { BarChart } from "@gooddata/sdk-ui-charts";
+
+    <BarChart
+        backend={backend}
+        workspace="<yourWorkspace>"
+        measures={[Ldm.Won]}
+        viewBy={[Ldm.Product]}
+    />
     ```
 
-* Use the newly available BackendProvider at the root of your application and remove use of the `sdk` property from 
+* Use the newly available BackendProvider at the root of your application and remove use of the `sdk` property from
 your application:
+
     ```jsx
+    import { BackendProvider } from "@gooddata/sdk-ui";
+    import { BarChart } from "@gooddata/sdk-ui-charts";
+
     <BackendProvider backend={backend}>
-        <BarChart 
+        <BarChart
             workspace="<yourProjectId>"
             measures={[Ldm.Won]}
-            viewBy={[Ldm.Product]} 
+            viewBy={[Ldm.Product]}
         />
     </BackendProvider>
     ```
 
-To learn more details about initialization, see the <link to getting started>. For more information about configuring 
+To learn more details about initialization, see the <link to getting started>. For more information about configuring
 important aspects such as authentication, see <link>.
 
 ## Model Infrastructure and Execution Changes
 
 ### Model Infrastructure
-We have overhauled the Model infrastructure. All its functionality is now in the `@gooddata/sdk-model` package. 
-The APIs from Version 7.0 were reworked and changed significantly. Functionality-wise, the Model infrastructure in 
+We have overhauled the Model infrastructure. All its functionality is now in the `@gooddata/sdk-model` package.
+The APIs from Version 7.0 were reworked and changed significantly. Functionality-wise, the Model infrastructure in
 Version 8.0 is a superset of what we had in Version 7.0.
 
-The main reason why we decided to make these changes is that we wanted GoodData.UI itself and all our applications 
-to use this Model infrastructure. While the syntax changes are numerous, everything that was possible with the Model 
+The main reason why we decided to make these changes is that we wanted GoodData.UI itself and all our applications
+to use this Model infrastructure. While the syntax changes are numerous, everything that was possible with the Model
 infrastructure in Version 7.0 is possible in Version 8.0 and with a fuller, more friendly and convenient API.
 
-To adopt this change, use the `catalog-export` tool to generate the logical data model (LDM) object definitions for you. 
-Unless your application works with arbitrary workspaces (where you do not know the LDM at compilation time), 
+To adopt this change, use the `catalog-export` tool to generate the logical data model (LDM) object definitions for you.
+Unless your application works with arbitrary workspaces (where you do not know the LDM at compilation time),
 it should use the generated LDM.
 
 For more information, see [Export Catalog](02_start__catalog_export.md).
 
 ### Execution
-The updated LDM objects feed seamlessly into the updated infrastructure and APIs that trigger executions. We have 
+The updated LDM objects feed seamlessly into the updated infrastructure and APIs that trigger executions. We have
 significantly modified how GoodData.UI communicates with the backend. The Execute AFM component is no longer in use.
 
-The API client package of the GoodData platform, `@gooddata/api-client-gd` (formerly known as `gooddata-js`), 
-still exposes the same functionality as it did before - you can find the "raw" Execute AFM functionality there. 
-However, we no longer use this directly in GoodData.UI, and we advise that you not do so either. Although the AFM 
-functionality is going to remain in the `api-client-gd` package, the layers that we built on it provide additional 
+The API client package of the GoodData platform, `@gooddata/api-client-gd` (formerly known as `gooddata-js`),
+still exposes the same functionality as it did before - you can find the "raw" Execute AFM functionality there.
+However, we no longer use this directly in GoodData.UI, and we advise that you not do so either. Although the AFM
+functionality is going to remain in the `api-client-gd` package, the layers that we built on it provide additional
 features and are easier to use.
 
-To adopt this change, migrate all custom executions so that they use the analytical backend SPI. The new entry 
-point to execution is: 
+To adopt this change, migrate all custom executions so that they use the analytical backend SPI. The new entry
+point to execution is:
 
 `backend.workspace(<projectId>).execution()`
 
-This is a gateway to the new execution APIs where you can set up custom execution with the same flexibility and 
-more convenience than with the lower-level Execute AFM component. 
+This is a gateway to the new execution APIs where you can set up custom execution with the same flexibility and
+more convenience than with the lower-level Execute AFM component.
 
-**NOTE:** For information about further levels of flexibility and performance that you can achieve with the new execution 
+**NOTE:** For information about further levels of flexibility and performance that you can achieve with the new execution
 infrastructure, see Advanced Topic: Backend Decorators.
 
 ## Changes in Component Props
-We have done additional, trivial breaking changes on the component level. They are mostly about renaming the props, 
-getting rid of obsolete, defunct or deprecated props. Apart from these types of changes, we have modified the 
+We have done additional, trivial breaking changes on the component level. They are mostly about renaming the props,
+getting rid of obsolete, defunct or deprecated props. Apart from these types of changes, we have modified the
 structure of drill events.
 
 ### Renamed Properties
-The `projectId` prop on the different visualizations has been renamed to `workspace`. The type and content of the prop 
+The `projectId` prop on the different visualizations has been renamed to `workspace`. The type and content of the prop
 remain the same: when integrating with the GoodData platform, the value represents the ID of a project.
 
 ### Deleted Properties
 
-We have determined that several props were included in the component APIs by mistake and were never used. Those props 
+We have determined that several props were included in the component APIs by mistake and were never used. Those props
 are `environment` and `onLoadingFinished` from the chart components. We deleted these props.
 
-Additionally, we deleted the `columnMeasure`s prop and the `lineMeasures` prop from the Combo Chart component. These props 
+Additionally, we deleted the `columnMeasure`s prop and the `lineMeasures` prop from the Combo Chart component. These props
 were deprecated with the introduction of primary and secondary measure props.
 
 ## Changes in the Drilling Area
 
-In Version 7.0, we introduced a couple of changes to drilling in a backward-compatible fashion, including the `onDrill` 
-callback. The events sent through this callback have a slightly different payload: the indicators in the intersection 
+In Version 7.0, we introduced a couple of changes to drilling in a backward-compatible fashion, including the `onDrill`
+callback. The events sent through this callback have a slightly different payload: the indicators in the intersection
 are more precise.
 
 In Version 8.0, we deleted the original drilling and kept only the new API. These are the most notable breaking changes:
@@ -210,10 +219,10 @@ In Version 8.0, we deleted the original drilling and kept only the new API. Thes
 -  The `onFiredDrillEvent` parameter has been deleted.
 -  The `onDrill` event is now the only callback for drill events.
 -  The `IDrillEvent` event and all events in its family have been deleted.
--  The `IDrillEventExtended` event has been renamed to `IDrillEvent`; the new events with extended header information 
+-  The `IDrillEventExtended` event has been renamed to `IDrillEvent`; the new events with extended header information
    are included.
--  The `executionContext` property (containing AFM) of drill events has been deleted. As a replacement, we have added 
-   the `dataView` property containing an instance of `IDataView`. 
+-  The `executionContext` property (containing AFM) of drill events has been deleted. As a replacement, we have added
+   the `dataView` property containing an instance of `IDataView`.
 -  The `HeaderPredicateFactory` property has been renamed to `HeaderPredicates`.
 
 The new data view is a superset of `executionContext`. It contains everything you may need:
@@ -221,16 +230,16 @@ The new data view is a superset of `executionContext`. It contains everything yo
 -  The execution result
 -  The data that was visualized at the time the user triggered the drill event
 
-On top of this, you can wrap an instance of the data view in `DataViewFacade`. `DataViewFacade` provides a host of added 
+On top of this, you can wrap an instance of the data view in `DataViewFacade`. `DataViewFacade` provides a host of added
 value functionality that you can use to work with the definition, data, or headers in a more convenient way.
 
 ## API Client Changes
 
-We have consolidated the `@gooddata/gooddata-js` and `@gooddata/typings` packages under the new gooddata-ui-sdk repository. 
-The `gooddata-js` package has been renamed to `@gooddata/api-client-bear`. The typings package has been renamed to 
+We have consolidated the `@gooddata/gooddata-js` and `@gooddata/typings` packages under the new gooddata-ui-sdk repository.
+The `gooddata-js` package has been renamed to `@gooddata/api-client-bear`. The typings package has been renamed to
 `@gooddata/api-model-bear`. Both new packages start with Version 8.0.
 
-On top of this, we have made several breaking changes to anchor the responsibilities of these packages to be low-level 
+On top of this, we have made several breaking changes to anchor the responsibilities of these packages to be low-level
 REST API wrappers.
 
 Most breaking changes have been made in the `@gooddata/api-model-bear` package (formerly known as `@gooddata/typings`).
@@ -243,8 +252,8 @@ The following  types and namespace have been removed and replaced with  alternat
 
 The following  namespaces and their contents have been renamed:
 
-| Old name | New name | 
-| :------- | :------- | 
+| Old name | New name |
+| :------- | :------- |
 | `ExecuteAFM` | `GdcExecuteAFM` |
 | `Execution` | `GdcExecution` |
 | `ExtendedDateFilters` | `GdcExtendedDateFilters` |

--- a/docs/clean_up_your_code.md
+++ b/docs/clean_up_your_code.md
@@ -15,15 +15,15 @@ In the tutorial [Create Your First Application](02_start__no_boilerplate.md), yo
 const measures = [
     {
         measure: {
-            localIdentifier: 'franchiseFeesIdentifier',
+            localIdentifier: "franchiseFeesIdentifier",
             definition: {
                 measureDefinition: {
                     item: {
-                        identifier: 'aaEGaXAEgB7U'
+                        identifier: "aaEGaXAEgB7U"
                     }
                 }
             },
-            format: '#,##0'
+            format: "#,##0"
         }
     }
 ];
@@ -32,11 +32,11 @@ const style = { height: 300 };
 
 <div style={style}>
   <LineChart
-      projectId='xms7ga4tf3g3nzucd8380o2bev8oeknp'
+      projectId="xms7ga4tf3g3nzucd8380o2bev8oeknp"
       measures={measures}
       trendBy={attribute}
       config={{
-          colors: ['#14b2e2']
+          colors: ["#14b2e2"]
       }}
   />
 </div>
@@ -74,29 +74,29 @@ After you installed the tool, do the following:
 2. Import the `catalog.json` file into your `App.js` file.
    You can now reference the measure using its human-readable alias \(`$ Franchise Fees`\) instead of its identifier \(`aaEGaXAEgB7U`\). Your new `App.js` file would look like the following:
     ```javascript
-    import React, { Component } from 'react';
-    import { LineChart } from '@gooddata/react-components';
-    import '@gooddata/react-components/styles/css/main.css';
+    import React, { Component } from "react";
+    import { LineChart } from "@gooddata/react-components";
+    import "@gooddata/react-components/styles/css/main.css";
 
-    import logo from './logo.svg';
-    import './App.css';
+    import logo from "./logo.svg";
+    import "./App.css";
 
-    import { CatalogHelper } from '@gooddata/react-components';
-    import catalogJson from './catalog.json';
+    import { CatalogHelper } from "@gooddata/react-components";
+    import catalogJson from "./catalog.json";
     const C = new CatalogHelper(catalogJson);
 
     const measures = [
     {
         measure: {
-            localIdentifier: 'franchiseFeesIdentifier',
+            localIdentifier: "franchiseFeesIdentifier",
             definition: {
                 measureDefinition: {
                     item: {
-                        identifier: C.measure('$ Franchise Fees')
+                        identifier: C.measure("$ Franchise Fees")
                     }
                 }
             },
-            format: '#,##0'
+            format: "#,##0"
         }
       }
     ];
@@ -104,9 +104,9 @@ After you installed the tool, do the following:
     const attribute = {
         visualizationAttribute: {
             displayForm: {
-                identifier: 'date.abm81lMifn6q'
+                identifier: "date.abm81lMifn6q"
             },
-            localIdentifier: 'month'
+            localIdentifier: "month"
         }
     };
 
@@ -120,11 +120,11 @@ After you installed the tool, do the following:
                 </div>
                 <div style={{ height: 300 }}>
                   <LineChart
-                      projectId='xms7ga4tf3g3nzucd8380o2bev8oeknp'
+                      projectId="xms7ga4tf3g3nzucd8380o2bev8oeknp"
                       measures={measures}
                       trendBy={attribute}
                       config={{
-                          colors: ['#14b2e2']
+                          colors: ["#14b2e2"]
                       }}
                   />
                 </div>

--- a/docs/data_layer.md
+++ b/docs/data_layer.md
@@ -33,7 +33,7 @@ Importing GoodData DataLayer dependencies
 and GoodData Java Script SDK
 (https://github.com/gooddata/gooddata-js)
 */
-import {factory as SdkFactory, DataLayer} from '@gooddata/gooddata-js';
+import {factory as SdkFactory, DataLayer} from "@gooddata/gooddata-js";
 const { DataTable, ExecuteAfmAdapter } = DataLayer;
 const sdk = SdkFactory();
 
@@ -43,11 +43,11 @@ Defining AFMs and (optionally) resultSpec
 const afm = {
     measures: [
         {
-            localIdentifier: 'measure1', // An identifier which will be referenced in the execution results
+            localIdentifier: "measure1", // An identifier which will be referenced in the execution results
             definition: {
                 measure: {
                     item: {
-                        identifier: '<measure-identifier>'
+                        identifier: "<measure-identifier>"
                     }
                 }
             }
@@ -58,7 +58,7 @@ const afm = {
 const resultSpec = {
     dimensions: [
         {
-            itemIdentifiers: ['measureGroup']
+            itemIdentifiers: ["measureGroup"]
         }
     ]
 };
@@ -67,7 +67,7 @@ const resultSpec = {
 Initializing the Adapter object
 The Adapter converts the AFMs for the backend to process.
 */
-const adapter = new ExecuteAfmAdapter(sdk, '<project-id>');
+const adapter = new ExecuteAfmAdapter(sdk, "<project-id>");
 
 /*
 Initializing the Data Table object

--- a/docs/live_examples.md
+++ b/docs/live_examples.md
@@ -7,4 +7,4 @@ id: live_examples
 
 Visit [Live Examples](https://gooddata-examples.herokuapp.com/).
 
-<script>window.location = 'https://gooddata-examples.herokuapp.com/';</script>
+<script>window.location = "https://gooddata-examples.herokuapp.com/";</script>

--- a/docs/table_totals_in_execution_context.md
+++ b/docs/table_totals_in_execution_context.md
@@ -34,7 +34,7 @@ execution : {
         ...
         nativeTotals: [
             {
-                measureIdentifier: 'm1',
+                measureIdentifier: "m1",
                 attributeIdentifiers: []
             }
         ]
@@ -43,22 +43,22 @@ execution : {
         ...
         dimensions: [
             {
-                itemIdentifiers: ['a1', 'a2'],
+                itemIdentifiers: ["a1", "a2"],
                 totals: [
                     {
-                        measureIdentifier: 'm1',
-                        type: 'sum',
-                        attributeIdentifier: 'a1'
+                        measureIdentifier: "m1",
+                        type: "sum",
+                        attributeIdentifier: "a1"
                     },
                     {
-                        measureIdentifier: 'm1',
-                        type: 'nat',
-                        attributeIdentifier: 'a1'
+                        measureIdentifier: "m1",
+                        type: "nat",
+                        attributeIdentifier: "a1"
                     }
                 ]
             },
             {
-                itemIdentifiers: ['measureGroup'],
+                itemIdentifiers: ["measureGroup"],
                 totals: []
             }
         ]

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -76,7 +76,6 @@
       "filter_visual_components",
       "create_custom_attribute_filter",
       "ht_render_visualization_from_different_domain",
-      "ht_use_react_components_with_vanilla_js",
       "ht_use_react_component_in_angular_2.x",
       "ht_create_predicates"
     ]


### PR DESCRIPTION
RAIL-2719 - fix formatting in Breaking changes
RAIL-1815 - unify all the quotes to double (we use those everywhere else in our codebase)
RAIL-1815 - remove obsolete vanilla js example from menu