### PR TITLE
RELATED: RAIL-3306 Remove misleading sentence in Headline docs

### DIFF
--- a/docs/10_vis__headline_component.md
+++ b/docs/10_vis__headline_component.md
@@ -5,7 +5,7 @@ copyright: (C) 2007-2018 GoodData Corporation
 id: headline_component
 ---
 
-A **headline** shows a single number or compares two numbers. You can display both measures and attributes.
+A **headline** shows a single number or compares two numbers.
 
 Headlines have two sections: Measure (primary) and Measure (secondary). You can add one item to each section. If you add two items, the headline also displays the change in percent.
 

--- a/website/versioned_docs/version-5.0.0/10_vis__headline_component.md
+++ b/website/versioned_docs/version-5.0.0/10_vis__headline_component.md
@@ -6,7 +6,7 @@ id: version-5.0.0-headline_component
 original_id: headline_component
 ---
 
-Headline shows a single number. Use headlines to display measures and attributes.
+Headline shows a single number.
 
 ![Headline Component](assets/headline.png "Headline Component")
 

--- a/website/versioned_docs/version-5.2.0/10_vis__headline_component.md
+++ b/website/versioned_docs/version-5.2.0/10_vis__headline_component.md
@@ -6,7 +6,7 @@ id: version-5.2.0-headline_component
 original_id: headline_component
 ---
 
-Headline shows a single number or compares two numbers. You can display both measures and attributes.
+Headline shows a single number or compares two numbers.
 
 Headlines have two sections: Measure (primary) and Measure (secondary). You can add one item to each section. If you add two items, the headline also displays the change in percent.
 

--- a/website/versioned_docs/version-6.3.0/10_vis__headline_component.md
+++ b/website/versioned_docs/version-6.3.0/10_vis__headline_component.md
@@ -6,7 +6,7 @@ id: version-6.3.0-headline_component
 original_id: headline_component
 ---
 
-Headline shows a single number or compares two numbers. You can display both measures and attributes.
+Headline shows a single number or compares two numbers.
 
 Headlines have two sections: Measure (primary) and Measure (secondary). You can add one item to each section. If you add two items, the headline also displays the change in percent.
 

--- a/website/versioned_docs/version-8.0.0/10_vis__headline_component.md
+++ b/website/versioned_docs/version-8.0.0/10_vis__headline_component.md
@@ -6,7 +6,7 @@ id: version-8.0.0-headline_component
 original_id: headline_component
 ---
 
-A **headline** shows a single number or compares two numbers. You can display both measures and attributes.
+A **headline** shows a single number or compares two numbers.
 
 Headlines have two sections: Measure (primary) and Measure (secondary). You can add one item to each section. If you add two items, the headline also displays the change in percent.
 


### PR DESCRIPTION
Headline only supports measures. Fixed in all versions since it was
never accurate, Headline has always supported Measures only.

JIRA: RAIL-3306