### PR TITLE
RELATED: RAIL-2767 improve versions page

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "docusaurus": "^1.14.7",
-    "sass": "^1.2.0"
+    "sass": "^1.2.0",
+    "semver": "^6.3.0"
   }
 }


### PR DESCRIPTION
Indicate support status of the individual versions
Remove support for prerelease versions (we do not use it anyway)
Simplify future configuration (use semver)

Note: uses semver 6 to keep IE compatibility (version 7 is not compatible).

![localhost_3000_gooddata-ui_versions html](https://user-images.githubusercontent.com/1748653/117809008-e7777380-b25d-11eb-9ebf-05748b94a4cb.png)
