### PR TITLE
RELATED: RAIL-3395 document TypeScript semver

### DIFF
--- a/docs/01_intro__about_gooddataui.md
+++ b/docs/01_intro__about_gooddataui.md
@@ -27,9 +27,9 @@ This documentation is intended for front-end software developers and requires Ja
 GoodData.UI is compatible with:
 
 * React >=16.8.0 <17.0.0, [Angular 9+](30_tips__use_angular_2.x.md)
-* [TypeScript](02_start__api_maturity.md#typescript-types-considerations) >=4.0.2, ES6, ES5
+* [TypeScript](02_start__api_maturity.md#typescript-type-considerations) >=4.0.2, ES6, ES5
 * Node ^12.15.0 LTS
-* [Officially supported browsers](https://help.gooddata.com/pages/viewpage.action?pageId=34340969)
+* [Officially supported browsers](https://help.gooddata.com/pages/viewpage.action?pageId=86775029)
 
 **NOTE:** [Server-side rendering](https://github.com/reactjs/redux/blob/master/docs/recipes/ServerRendering.md) is *not* supported.
 

--- a/docs/01_intro__about_gooddataui.md
+++ b/docs/01_intro__about_gooddataui.md
@@ -27,7 +27,7 @@ This documentation is intended for front-end software developers and requires Ja
 GoodData.UI is compatible with:
 
 * React >=16.8.0 <17.0.0, [Angular 9+](30_tips__use_angular_2.x.md)
-* TypeScript >=3.3.4000, ES6, ES5
+* TypeScript >=4.0.2, ES6, ES5
 * Node ^12.15.0 LTS
 * [Officially supported browsers](https://help.gooddata.com/pages/viewpage.action?pageId=34340969)
 

--- a/docs/01_intro__about_gooddataui.md
+++ b/docs/01_intro__about_gooddataui.md
@@ -27,7 +27,7 @@ This documentation is intended for front-end software developers and requires Ja
 GoodData.UI is compatible with:
 
 * React >=16.8.0 <17.0.0, [Angular 9+](30_tips__use_angular_2.x.md)
-* TypeScript >=4.0.2, ES6, ES5
+* [TypeScript](02_start__api_maturity.md#typescript-types-considerations) >=4.0.2, ES6, ES5
 * Node ^12.15.0 LTS
 * [Officially supported browsers](https://help.gooddata.com/pages/viewpage.action?pageId=34340969)
 

--- a/docs/02_start__api_maturity.md
+++ b/docs/02_start__api_maturity.md
@@ -25,14 +25,14 @@ or patch versions work seamlessly.
 
 On top of this, we strongly recommend that you use the same version of all GoodData.UI packages.
 
-## TypeScript types considerations
+## TypeScript type considerations
 
 All the TypeScript types provided with the GoodData.UI packages are compatible with TypeScript version 4.0.2 and newer.
 
-The types marked as `@public` will generally adhere to the SemVer specification,
-however there is one group of types that will not adhere to it completely: types of the React props of all the components
-in the `sdk-ui-*` packages. These types will be backwards compatible in the sense that creating objects of those
-types will work across minor versions, however we may extend them even across minor releases. An example of such change:
+The types marked as `@public` adhere to the SemVer specification except for the types of the React props of all the components
+in the `sdk-ui-*` package. These types are backward-compatible with respect to versions (that is, creating objects of those types will work across minor versions); however, we may extend them even across minor releases. We chose this approach to allow us to add new features and extend the existing ones without having to release a major version.
+
+Here is an example of such change:
 
 ```tsx
 // in an older version
@@ -51,7 +51,7 @@ export interface IExampleProps {
     sampleProp={42}
 />
 
-// however your custom functions using the type can break
+// however, your custom functions using the type can break
 function getSampleProp(props: IExampleProps): number {
     return props.sampleProp; // breaks with newer version as this is now (number | string)
 }
@@ -63,5 +63,4 @@ function getSampleProp(props: { sampleProp: number }): number {
 
 ```
 
-This will not affect 99% of the common use cases, but can be problematic if you for example use these types in your own functions (as shown in the`getSampleProp` example).
-We chose this approach to allow us to add and extend existing features without having to release a major version each time.
+This is not going to be an issue for most of the common use cases. It may become an issue if you, for example, use these types in your own functions as shown earlier in the `getSampleProp` example.

--- a/docs/02_start__api_maturity.md
+++ b/docs/02_start__api_maturity.md
@@ -11,10 +11,10 @@ APIs are.
 
 The API Maturity annotations are as follows:
 
--  **@alpha**: initial API; highly likely to change outside of the SemVer specification 
--  **@beta**: mostly stable API; details may change outside of the SemVer specification 
--  **@public**: stable API; follows the SemVer specification 
--  **@internal**: internal API; may change or disappear at any time 
+-  **@alpha**: initial API; highly likely to change outside of the SemVer specification
+-  **@beta**: mostly stable API; details may change outside of the SemVer specification
+-  **@public**: stable API; follows the SemVer specification
+-  **@internal**: internal API; may change or disappear at any time
 
 All this documentation is included in the published packages so that you can conveniently access it in an IDE of your choice.
 
@@ -24,3 +24,44 @@ Use only the exported APIs annotated as **@public**. Doing this guarantees that 
 or patch versions work seamlessly.
 
 On top of this, we strongly recommend that you use the same version of all GoodData.UI packages.
+
+## TypeScript types considerations
+
+All the TypeScript types provided with the GoodData.UI packages are compatible with TypeScript version 4.0.2 and newer.
+
+The types marked as `@public` will generally adhere to the SemVer specification,
+however there is one group of types that will not adhere to it completely: types of the React props of all the components
+in the `sdk-ui-*` packages. These types will be backwards compatible in the sense that creating objects of those
+types will work across minor versions, however we may extend them even across minor releases. An example of such change:
+
+```tsx
+// in an older version
+export interface IExampleProps {
+    sampleProp: number;
+}
+
+// in a newer version
+export interface IExampleProps {
+    sampleProp: number | string;
+    addedProp?: boolean;
+}
+
+// calling the component is OK in both versions
+<Example
+    sampleProp={42}
+/>
+
+// however your custom functions using the type can break
+function getSampleProp(props: IExampleProps): number {
+    return props.sampleProp; // breaks with newer version as this is now (number | string)
+}
+
+// to avoid this, consider creating an explicit copy of the type or type the function like this:
+function getSampleProp(props: { sampleProp: number }): number {
+    return props.sampleProp; // works with both versions
+}
+
+```
+
+This will not affect 99% of the common use cases, but can be problematic if you for example use these types in your own functions (as shown in the`getSampleProp` example).
+We chose this approach to allow us to add and extend existing features without having to release a major version each time.

--- a/website/versioned_docs/version-8.0.0/01_intro__about_gooddataui.md
+++ b/website/versioned_docs/version-8.0.0/01_intro__about_gooddataui.md
@@ -29,7 +29,7 @@ This documentation is intended for front-end software developers and requires Ja
 GoodData.UI is compatible with:
 
 * React >=16.8.0, [Angular 9+](30_tips__use_angular_2.x.md)
-* TypeScript >=3.3.4000, ES6, ES5
+* TypeScript >=4.0.2, ES6, ES5
 * Node ^12.15.0 LTS
 * [Officially supported browsers](https://help.gooddata.com/display/doc/System+Requirements+and+Supported+Browsers)
 

--- a/website/versioned_docs/version-8.2.0/01_intro__about_gooddataui.md
+++ b/website/versioned_docs/version-8.2.0/01_intro__about_gooddataui.md
@@ -29,7 +29,7 @@ This documentation is intended for front-end software developers and requires Ja
 GoodData.UI is compatible with:
 
 * React >=16.8.0, [Angular 9+](30_tips__use_angular_2.x.md)
-* TypeScript >=3.3.4000, ES6, ES5
+* TypeScript >=4.0.2, ES6, ES5
 * Node ^12.15.0 LTS
 * [Officially supported browsers](https://help.gooddata.com/pages/viewpage.action?pageId=34340969)
 

--- a/website/versioned_docs/version-8.3.0/01_intro__about_gooddataui.md
+++ b/website/versioned_docs/version-8.3.0/01_intro__about_gooddataui.md
@@ -28,7 +28,7 @@ This documentation is intended for front-end software developers and requires Ja
 GoodData.UI is compatible with:
 
 * React >=16.8.0 <17.0.0, [Angular 9+](30_tips__use_angular_2.x.md)
-* TypeScript >=3.3.4000, ES6, ES5
+* TypeScript >=4.0.2, ES6, ES5
 * Node ^12.15.0 LTS
 * [Officially supported browsers](https://help.gooddata.com/pages/viewpage.action?pageId=34340969)
 


### PR DESCRIPTION
* fix the version supported of TypeScript (it was always 4.0.2 for SDK8)
* document how we interpret semver in regards to types