### PR TITLE
RELATED: RAIL-3486 remove Table mentions from SDK 8+

### DIFF
--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -46,7 +46,6 @@
       "pie_chart_component",
       "pivot_table_component",
       "scatter_plot_component",
-      "table_component",
       "treemap_component",
       "visualization_component",
       "dashboard_view_component",

--- a/website/versioned_sidebars/version-8.0.0-sidebars.json
+++ b/website/versioned_sidebars/version-8.0.0-sidebars.json
@@ -37,7 +37,6 @@
       "version-8.0.0-pie_chart_component",
       "version-8.0.0-pivot_table_component",
       "version-8.0.0-scatter_plot_component",
-      "version-8.0.0-table_component",
       "version-8.0.0-treemap_component",
       "version-8.0.0-visualization_component",
       "version-8.0.0-attribute_filter_component",

--- a/website/versioned_sidebars/version-8.1.0-sidebars.json
+++ b/website/versioned_sidebars/version-8.1.0-sidebars.json
@@ -38,7 +38,6 @@
       "version-8.1.0-pie_chart_component",
       "version-8.1.0-pivot_table_component",
       "version-8.1.0-scatter_plot_component",
-      "version-8.1.0-table_component",
       "version-8.1.0-treemap_component",
       "version-8.1.0-visualization_component",
       "version-8.1.0-attribute_filter_component",

--- a/website/versioned_sidebars/version-8.2.0-sidebars.json
+++ b/website/versioned_sidebars/version-8.2.0-sidebars.json
@@ -38,7 +38,6 @@
       "version-8.2.0-pie_chart_component",
       "version-8.2.0-pivot_table_component",
       "version-8.2.0-scatter_plot_component",
-      "version-8.2.0-table_component",
       "version-8.2.0-treemap_component",
       "version-8.2.0-visualization_component",
       "version-8.2.0-dashboard_view_component",

--- a/website/versioned_sidebars/version-8.3.0-sidebars.json
+++ b/website/versioned_sidebars/version-8.3.0-sidebars.json
@@ -46,7 +46,6 @@
       "version-8.3.0-pie_chart_component",
       "version-8.3.0-pivot_table_component",
       "version-8.3.0-scatter_plot_component",
-      "version-8.3.0-table_component",
       "version-8.3.0-treemap_component",
       "version-8.3.0-visualization_component",
       "version-8.3.0-dashboard_view_component",

--- a/website/versioned_sidebars/version-8.4.0-sidebars.json
+++ b/website/versioned_sidebars/version-8.4.0-sidebars.json
@@ -46,7 +46,6 @@
       "version-8.4.0-pie_chart_component",
       "version-8.4.0-pivot_table_component",
       "version-8.4.0-scatter_plot_component",
-      "version-8.4.0-table_component",
       "version-8.4.0-treemap_component",
       "version-8.4.0-visualization_component",
       "version-8.4.0-dashboard_view_component",


### PR DESCRIPTION
The Table was removed in SDK8 so there is no reason to show it
in the left menu there.