### PR TITLE
RELATED: RAIL-3587 make the How to use more prominent

### DIFF
--- a/docs/02_start__using_boilerplate.md
+++ b/docs/02_start__using_boilerplate.md
@@ -7,6 +7,8 @@ id: create_new_application
 
 Create your first analytical application using the **`@gooddata/create-gooddata-react-app`** tool.
 
+## About `@gooddata/create-gooddata-react-app`
+
 `@gooddata/create-gooddata-react-app` is a CLI-based tool that will guide you through the process of creating the application
 step by step in your terminal application.
 
@@ -23,6 +25,8 @@ This is what is going to happen when you run `@gooddata/create-gooddata-react-ap
 2. When completed, it will ask you to select your domain from the list or let you enter your domain name manually.
 3. Once you confirm your domain, the tool will install required dependencies and create the structure of your application.
 4. It will then prompt you to start your application and will open the welcome page in your browser.
+
+## How to use `@gooddata/create-gooddata-react-app`
 
 To start, go to [https://github.com/gooddata/gooddata-create-gooddata-react-app](https://github.com/gooddata/gooddata-create-gooddata-react-app), and follow the instructions in the README file.
 The created application contains its own README with further information about configuration, build and deployment options.

--- a/website/versioned_docs/version-8.0.0/02_start__using_boilerplate.md
+++ b/website/versioned_docs/version-8.0.0/02_start__using_boilerplate.md
@@ -8,6 +8,8 @@ original_id: ht_create_your_first_visualization_toolkit
 
 Create your first analytical application using GoodData **`create-gooddata-react-app`** and **Accelerator Toolkit**.
 
+## About `create-gooddata-react-app`
+
 `create-gooddata-react-app` is a CLI-based tool that will guide you through the process of creating the application step by step in your terminal application.
 
 This is what is going to happen when you run `create-gooddata-react-app`:
@@ -16,6 +18,8 @@ This is what is going to happen when you run `create-gooddata-react-app`:
 2. When completed, it will ask you to select your domain from the list or let you enter your domain name manually.
 3. Once you confirm your domain, the tool will install required dependencies and create the structure of your application.
 4. It will then prompt you to start your application and will open the welcome page in your browser. The welcome page refer you to Accelerator Toolkit, which will allow you to set up your home dashboard with a test widget.
+
+## How to use `create-gooddata-react-app`
 
 To start, go to [https://github.com/gooddata/gooddata-create-gooddata-react-app](https://github.com/gooddata/gooddata-create-gooddata-react-app), and follow the instructions in the README file.
 

--- a/website/versioned_docs/version-8.3.0/02_start__using_boilerplate.md
+++ b/website/versioned_docs/version-8.3.0/02_start__using_boilerplate.md
@@ -8,6 +8,8 @@ original_id: create_new_application
 
 Create your first analytical application using the **`@gooddata/create-gooddata-react-app`** tool.
 
+## About `@gooddata/create-gooddata-react-app`
+
 `@gooddata/create-gooddata-react-app` is a CLI-based tool that will guide you through the process of creating the application
 step by step in your terminal application.
 
@@ -24,6 +26,8 @@ This is what is going to happen when you run `@gooddata/create-gooddata-react-ap
 2. When completed, it will ask you to select your domain from the list or let you enter your domain name manually.
 3. Once you confirm your domain, the tool will install required dependencies and create the structure of your application.
 4. It will then prompt you to start your application and will open the welcome page in your browser. The welcome page refer you to Accelerator Toolkit, which will allow you to set up your home dashboard with a test widget.
+
+## How to use `@gooddata/create-gooddata-react-app`
 
 To start, go to [https://github.com/gooddata/gooddata-create-gooddata-react-app](https://github.com/gooddata/gooddata-create-gooddata-react-app), and follow the instructions in the README file.
 The created application contains its own README with further information about configuration, build and deployment options.

--- a/website/versioned_docs/version-8.5.0/02_start__using_boilerplate.md
+++ b/website/versioned_docs/version-8.5.0/02_start__using_boilerplate.md
@@ -8,6 +8,8 @@ original_id: create_new_application
 
 Create your first analytical application using the **`@gooddata/create-gooddata-react-app`** tool.
 
+## About `@gooddata/create-gooddata-react-app`
+
 `@gooddata/create-gooddata-react-app` is a CLI-based tool that will guide you through the process of creating the application
 step by step in your terminal application.
 
@@ -24,6 +26,8 @@ This is what is going to happen when you run `@gooddata/create-gooddata-react-ap
 2. When completed, it will ask you to select your domain from the list or let you enter your domain name manually.
 3. Once you confirm your domain, the tool will install required dependencies and create the structure of your application.
 4. It will then prompt you to start your application and will open the welcome page in your browser.
+
+## How to use `@gooddata/create-gooddata-react-app`
 
 To start, go to [https://github.com/gooddata/gooddata-create-gooddata-react-app](https://github.com/gooddata/gooddata-create-gooddata-react-app), and follow the instructions in the README file.
 The created application contains its own README with further information about configuration, build and deployment options.


### PR DESCRIPTION
Previously, the most important link to use was drowned in a wall of text.
This adds headers so the user can scan the page more efficiently
if they don't care about the details described above.