### PR TITLE
RELATED: SD-1688 Rename project to workspace in GD.UI SDK docs

### DIFF
--- a/docs/30_tips__use_different_domains.md
+++ b/docs/30_tips__use_different_domains.md
@@ -34,14 +34,14 @@ export default class SampleVisualizations extends PureComponent {
                 <div style={{ height: 400, width: 600 }}>
                     <InsightView
                         backend={this.backend1}
-                        workspace="<projectId-from-backend1>"
+                        workspace="<workspaceId-from-backend1>"
                         insight="<identifier-from-backend1>"
                     />
                 </div>
                 <div style={{ height: 400, width: 600 }}>
                     <InsightView
                         backend={this.backend2}
-                        workspace="<projectId-from-backend2>"
+                        workspace="<workspaceId-from-backend2>"
                         insight="<identifier-from-backend2>"
                     />
                 </div>

--- a/docs/breaking_changes_8.md
+++ b/docs/breaking_changes_8.md
@@ -183,7 +183,7 @@ features and are easier to use.
 To adopt this change, migrate all custom executions so that they use the analytical backend SPI. The new entry
 point to execution is:
 
-`backend.workspace(<projectId>).execution()`
+`backend.workspace(<workspaceId>).execution()`
 
 This is a gateway to the new execution APIs where you can set up custom execution with the same flexibility and
 more convenience than with the lower-level Execute AFM component.

--- a/website/versioned_docs/version-4.1.1/30_tips__use_with_vanilla_js.md
+++ b/website/versioned_docs/version-4.1.1/30_tips__use_with_vanilla_js.md
@@ -29,7 +29,7 @@ The sample code at https://github.com/gooddata/ui-sdk-examples/tree/master/vanil
 
 ## Step 1. Prepare the bundle
 
-Create a simplenode.jsproject with a package.json descriptor and an entry point JavaScript file.
+Create a simple node.js project with a package.json descriptor and an entry point JavaScript file.
 
 ### Webpack configuration file
 

--- a/website/versioned_docs/version-5.0.0/30_tips__use_different_domains.md
+++ b/website/versioned_docs/version-5.0.0/30_tips__use_different_domains.md
@@ -35,14 +35,14 @@ export default class SampleVisualizations extends PureComponent {
                 <div style={{ height: 400, width: 600 }}>
                     <Visualization
                         identifier="<identifier-from-domain1>"
-                        projectId="<projectId-from-domain1>"
+                        projectId="<workspaceId-from-domain1>"
                         sdk={this.sdkDomain1}
                     />
                 </div>
                 <div style={{ height: 400, width: 600 }}>
                     <Visualization
                         identifier="<identifier-from-domain2>"
-                        projectId="<projectId-from-domain2>"
+                        projectId="<workspaceId-from-domain2>"
                         sdk={this.sdkDomain2}
                     />
                 </div>

--- a/website/versioned_docs/version-8.0.0/30_tips__use_different_domains.md
+++ b/website/versioned_docs/version-8.0.0/30_tips__use_different_domains.md
@@ -35,14 +35,14 @@ export default class SampleVisualizations extends PureComponent {
                 <div style={{ height: 400, width: 600 }}>
                     <InsightView
                         backend={this.backend1}
-                        workspace="<projectId-from-backend1>"
+                        workspace="<workspaceId-from-backend1>"
                         insight="<identifier-from-backend1>"
                     />
                 </div>
                 <div style={{ height: 400, width: 600 }}>
                     <InsightView
                         backend={this.backend2}
-                        workspace="<projectId-from-backend2>"
+                        workspace="<workspaceId-from-backend2>"
                         insight="<identifier-from-backend2>"
                     />
                 </div>

--- a/website/versioned_docs/version-8.0.0/breaking_changes_8.md
+++ b/website/versioned_docs/version-8.0.0/breaking_changes_8.md
@@ -184,7 +184,7 @@ features and are easier to use.
 To adopt this change, migrate all custom executions so that they use the analytical backend SPI. The new entry
 point to execution is:
 
-`backend.workspace(<projectId>).execution()`
+`backend.workspace(<workspaceId>).execution()`
 
 This is a gateway to the new execution APIs where you can set up custom execution with the same flexibility and
 more convenience than with the lower-level Execute AFM component.


### PR DESCRIPTION
Handle pattern "<projectId" → "<workspaceId" and some missing cases