### PR TITLE
RELATED: RAIL-3921 Pin create-react-app calls to version 4

### DIFF
--- a/website/versioned_docs/version-6.0.0/02_start__no_boilerplate.md
+++ b/website/versioned_docs/version-6.0.0/02_start__no_boilerplate.md
@@ -19,10 +19,11 @@ After you complete this tutorial, you will be able to display various measures 
 Run the following command from the command line:
 
 ```bash
-yarn global add create-react-app
+yarn global add create-react-app@4
 ```
 
-This command installs the `create-react-app` tool that will help you create a functional skeleton of a React application. The current version of `create-react-app` installs React 16. This version supports TypeScript ([`@gooddata/typings`](https://github.com/gooddata/gooddata-typings)).
+This command installs the `create-react-app` tool that will help you create a functional skeleton of a React application. We use `create-react-app` at **version 4** because it installs React **16**, which is compatible with GoodData.UI. `create-react-app` version 5 or higher is not supported.
+`create-react-app` version 4 supports TypeScript ([`@gooddata/typings`](https://github.com/gooddata/gooddata-typings)).
 
 **NOTE:** The supported versions of Node are ^8.10.0 or >=9.10.0. Using a different version may result in errors.
 

--- a/website/versioned_docs/version-6.1.0/02_start__no_boilerplate.md
+++ b/website/versioned_docs/version-6.1.0/02_start__no_boilerplate.md
@@ -19,10 +19,11 @@ After you complete this tutorial, you will be able to display various measures 
 Run the following command from the command line:
 
 ```bash
-yarn global add create-react-app
+yarn global add create-react-app@4
 ```
 
-This command installs the `create-react-app` tool that will help you create a functional skeleton of a React application. The current version of `create-react-app` installs React 16. This version supports TypeScript ([`@gooddata/typings`](https://github.com/gooddata/gooddata-typings)).
+This command installs the `create-react-app` tool that will help you create a functional skeleton of a React application. We use `create-react-app` at **version 4** because it installs React **16**, which is compatible with GoodData.UI. `create-react-app` version 5 or higher is not supported.
+`create-react-app` version 4 supports TypeScript ([`@gooddata/typings`](https://github.com/gooddata/gooddata-typings)).
 
 **NOTE:** The supported versions of Node are ^8.10.0 or >=9.10.0. Using a different version may result in errors.
 

--- a/website/versioned_docs/version-6.3.0/02_start__no_boilerplate.md
+++ b/website/versioned_docs/version-6.3.0/02_start__no_boilerplate.md
@@ -19,10 +19,11 @@ After you complete this tutorial, you will be able to display various measures 
 Run the following command from the command line:
 
 ```bash
-yarn global add create-react-app
+yarn global add create-react-app@4
 ```
 
-This command installs the `create-react-app` tool that will help you create a functional skeleton of a React application. The current version of `create-react-app` installs React 16. This version supports TypeScript ([`@gooddata/typings`](https://github.com/gooddata/gooddata-typings)).
+This command installs the `create-react-app` tool that will help you create a functional skeleton of a React application. We use `create-react-app` at **version 4** because it installs React **16**, which is compatible with GoodData.UI. `create-react-app` version 5 or higher is not supported.
+`create-react-app` version 4 supports TypeScript ([`@gooddata/typings`](https://github.com/gooddata/gooddata-typings)).
 
 **NOTE:** The supported versions of Node are ^8.10.0 or >=9.10.0. Using a different version may result in errors.
 

--- a/website/versioned_docs/version-7.1.0/02_start__no_boilerplate.md
+++ b/website/versioned_docs/version-7.1.0/02_start__no_boilerplate.md
@@ -20,10 +20,11 @@ After you complete this tutorial, you will be able to display various measures 
 Run the following command from the command line:
 
 ```bash
-yarn global add create-react-app
+yarn global add create-react-app@4
 ```
 
-This command installs the `create-react-app` tool that will help you create a functional skeleton of a React application. The current version of `create-react-app` installs React 16. This version supports TypeScript ([`@gooddata/typings`](https://github.com/gooddata/gooddata-typings)).
+This command installs the `create-react-app` tool that will help you create a functional skeleton of a React application. We use `create-react-app` at **version 4** because it installs React **16**, which is compatible with GoodData.UI. `create-react-app` version 5 or higher is not supported.
+`create-react-app` version 4 supports TypeScript ([`@gooddata/typings`](https://github.com/gooddata/gooddata-typings)).
 
 **NOTE:** The supported versions of Node are ^8.10.0 or >=9.10.0. Using a different version may result in errors.
 

--- a/website/versioned_docs/version-7.2.0/02_start__no_boilerplate.md
+++ b/website/versioned_docs/version-7.2.0/02_start__no_boilerplate.md
@@ -20,10 +20,11 @@ After you complete this tutorial, you will be able to display various measures 
 Run the following command from the command line:
 
 ```bash
-yarn global add create-react-app
+yarn global add create-react-app@4
 ```
 
-This command installs the `create-react-app` tool that will help you create a functional skeleton of a React application. The current version of `create-react-app` installs React 16. This version supports TypeScript ([`@gooddata/typings`](https://github.com/gooddata/gooddata-typings)).
+This command installs the `create-react-app` tool that will help you create a functional skeleton of a React application. We use `create-react-app` at **version 4** because it installs React **16**, which is compatible with GoodData.UI. `create-react-app` version 5 or higher is not supported.
+`create-react-app` version 4 supports TypeScript ([`@gooddata/typings`](https://github.com/gooddata/gooddata-typings)).
 
 **NOTE:** The supported versions of Node are ^8.10.0 or >=9.10.0. Using a different version may result in errors.
 
@@ -186,7 +187,7 @@ Now, you can start adding your first GoodData component:
     import '@gooddata/react-components/styles/css/main.css';
 
     import './App.css';
-   
+
     const measures = [
         {
             measure: {

--- a/website/versioned_docs/version-8.0.0/02_start__no_boilerplate.md
+++ b/website/versioned_docs/version-8.0.0/02_start__no_boilerplate.md
@@ -21,10 +21,11 @@ _Note: This tutorial assumes that you already have an existing GoodData account.
 Run the following command from the command line:
 
 ```bash
-yarn global add create-react-app
+yarn global add create-react-app@4
 ```
 
-This command installs the `create-react-app` tool that will help you create a functional skeleton of a React application. The current version of `create-react-app` installs React 16. This version supports TypeScript ([`@gooddata/typings`](https://github.com/gooddata/gooddata-typings)).
+This command installs the `create-react-app` tool that will help you create a functional skeleton of a React application. We use `create-react-app` at **version 4** because it installs React **16**, which is compatible with GoodData.UI. `create-react-app` version 5 or higher is not supported.
+`create-react-app` version 4 supports TypeScript.
 
 **NOTE:** The supported versions of Node are ^8.10.0 or >=9.10.0. Using a different version may result in errors.
 

--- a/website/versioned_docs/version-8.1.0/02_start__no_boilerplate.md
+++ b/website/versioned_docs/version-8.1.0/02_start__no_boilerplate.md
@@ -21,10 +21,11 @@ _Note: This tutorial assumes that you already have an existing GoodData account.
 Run the following command from the command line:
 
 ```bash
-yarn global add create-react-app
+yarn global add create-react-app@4
 ```
 
-This command installs the `create-react-app` tool that will help you create a functional skeleton of a React application. The current version of `create-react-app` installs React 16. This version supports TypeScript ([`@gooddata/typings`](https://github.com/gooddata/gooddata-typings)).
+This command installs the `create-react-app` tool that will help you create a functional skeleton of a React application. We use `create-react-app` at **version 4** because it installs React **16**, which is compatible with GoodData.UI. `create-react-app` version 5 or higher is not supported.
+`create-react-app` version 4 supports TypeScript.
 
 **NOTE:** The supported versions of Node are ^8.10.0 or >=9.10.0. Using a different version may result in errors.
 

--- a/website/versioned_docs/version-8.2.0/02_start__no_boilerplate.md
+++ b/website/versioned_docs/version-8.2.0/02_start__no_boilerplate.md
@@ -20,9 +20,9 @@ _Note: This tutorial assumes that you already have an existing GoodData account.
 
 1. Run the following command from the command line:
     ```bash
-    npx create-react-app my-first-app
+    npx create-react-app@4 my-first-app
     ```
-    This command creates a directory named `my-first-app` with a functional skeleton of a React application. You can see the command output that looks something like the following:
+    This command creates a directory named `my-first-app` with a functional skeleton of a React application. We use `create-react-app` at **version 4** because it installs React **16**, which is compatible with GoodData.UI. `create-react-app` version 5 or higher is not supported. You can see the command output that looks something like the following:
     ```bash
     Success! Created my-first-app at /Users/user-name/dev/my-first-app
     ```


### PR DESCRIPTION
This prevents errors with version 5 of the create-react-app
that is not working with neither SDK7 nor SDK8 at the moment.

Also remove nonsensical mention of @gooddata/typings in versions related
to SDK8, typings are only relevant to versions <= 7.

JIRA: RAIL-3921