### PR TITLE
RELATED: RAIL-3963 Fix breaking changes links in version 8.0.0

### DIFF
--- a/docs/breaking_changes_8.md
+++ b/docs/breaking_changes_8.md
@@ -151,7 +151,7 @@ your application:
     ```
 
 To learn more details about initialization, see [Getting started](02_start__using_boilerplate.md).
-For more information about integration into an existing application see either [GoodData platform guide](02_start__no_boilerplate.md) or [GoodData.CN guide](06_cloudnative__integration.md).
+For more information about integration into an existing application, see either [GoodData platform guide](02_start__no_boilerplate.md) or [GoodData.CN guide](06_cloudnative__integration.md).
 
 ## Model Infrastructure and Execution Changes
 

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -1825,6 +1825,10 @@
         "title": "Custom Executions",
         "sidebar_label": "Custom Executions"
       },
+      "version-8.3.0/version-8.3.0-breaking_changes_8": {
+        "title": "Breaking Changes in Version 8.0",
+        "sidebar_label": "Breaking Changes in Version 8.0"
+      },
       "version-8.4.0/version-8.4.0-about_gooddataui": {
         "title": "About GoodData.UI",
         "sidebar_label": "About GoodData.UI"

--- a/website/versioned_docs/version-8.0.0/breaking_changes_8.md
+++ b/website/versioned_docs/version-8.0.0/breaking_changes_8.md
@@ -152,7 +152,7 @@ your application:
     ```
 
 To learn more details about initialization, see [Getting started](02_start__using_boilerplate.md).
-For more information about integration into an existing application see either [GoodData platform guide](02_start__no_boilerplate.md) or [GoodData.CN guide](06_cloudnative__integration.md).
+For more information about integration into an existing application, see [installation guide](02_start__installation.md).
 
 ## Model Infrastructure and Execution Changes
 

--- a/website/versioned_docs/version-8.3.0/breaking_changes_8.md
+++ b/website/versioned_docs/version-8.3.0/breaking_changes_8.md
@@ -2,7 +2,7 @@
 title: Breaking Changes in Version 8.0
 sidebar_label: Breaking Changes in Version 8.0
 copyright: (C) 2007-2019 GoodData Corporation
-id: version-8.8.0-breaking_changes_8
+id: version-8.3.0-breaking_changes_8
 original_id: breaking_changes_8
 ---
 
@@ -130,8 +130,8 @@ To adopt these changes, create the backend once and then do **one** of the follo
     <BarChart
         backend={backend}
         workspace="<yourWorkspace>"
-        measures={[Md.Won]}
-        viewBy={[Md.Product]}
+        measures={[Ldm.Won]}
+        viewBy={[Ldm.Product]}
     />
     ```
 
@@ -145,8 +145,8 @@ your application:
     <BackendProvider backend={backend}>
         <BarChart
             workspace="<yourWorkspaceId>"
-            measures={[Md.Won]}
-            viewBy={[Md.Product]}
+            measures={[Ldm.Won]}
+            viewBy={[Ldm.Product]}
         />
     </BackendProvider>
     ```
@@ -169,7 +169,7 @@ To adopt this change, use the `catalog-export` tool to generate the logical data
 Unless your application works with arbitrary workspaces (where you do not know the LDM at compilation time),
 it should use the generated LDM.
 
-For more information, see [Export Catalog](02_start__catalog_export.md).
+For more information, see [Export Catalog](gdc_catalog_export).
 
 ### Execution
 The updated LDM objects feed seamlessly into the updated infrastructure and APIs that trigger executions. We have


### PR DESCRIPTION
The previous fix in this area was not ideal, since the GoodData.CN parts
are only available since 8.3.0, so the older versions had dead links.

Hence a new version of the page was added to cover versions 8.3.0 and up.

JIRA: RAIL-3963