### PR TITLE
RELATED: RAIL-4021 Automatically resize Roadmap

### DIFF
--- a/docs/01_intro__roadmap.md
+++ b/docs/01_intro__roadmap.md
@@ -5,4 +5,11 @@ copyright: (C) 2007-2021 GoodData Corporation
 id: roadmap
 ---
 
-<iframe src="https://portal.productboard.com/lrmhupnda99qqd4uofvozs4j/tabs/9-planned" frameborder="0" height="700px" width="100%" />
+<iframe
+    id="roadmap"
+    src="https://portal.productboard.com/lrmhupnda99qqd4uofvozs4j/tabs/9-planned"
+    frameborder="0"
+    height="700px"
+    width="100%"
+    onload="resizeRoadmap()"
+/>

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -75,7 +75,8 @@ const siteConfig = {
   },
   scripts: [
     'https://buttons.github.io/buttons.js',
-    '/gooddata-ui/js/toggleNav.js'
+    '/gooddata-ui/js/toggleNav.js',
+    '/gooddata-ui/js/resizeRoadmap.js'
   ],
   // You may provide arbitrary config keys to be used as needed by your template.
   repoUrl: 'https://github.com/gooddata/gooddata-ui-sdk',

--- a/website/static/js/resizeRoadmap.js
+++ b/website/static/js/resizeRoadmap.js
@@ -1,0 +1,15 @@
+function resizeRoadmap() {
+    var iframe = document.getElementById("roadmap");
+    var header = document.getElementsByClassName("fixedHeaderContainer")[0];
+    var postHeader = document.getElementsByClassName("postHeader")[0];
+    if (!iframe || !header || !postHeader) {
+        return;
+    }
+
+    // leave some extra padding around the iframe to give it some space
+    var padding = 100;
+    iframe.setAttribute(
+        "height",
+        window.innerHeight - header.scrollHeight - postHeader.scrollHeight - padding
+    );
+}

--- a/website/versioned_docs/version-8.7.0/01_intro__roadmap.md
+++ b/website/versioned_docs/version-8.7.0/01_intro__roadmap.md
@@ -6,4 +6,11 @@ id: version-8.7.0-roadmap
 original_id: roadmap
 ---
 
-<iframe src="https://portal.productboard.com/lrmhupnda99qqd4uofvozs4j/tabs/9-planned" frameborder="0" height="700px" width="100%" />
+<iframe
+    id="roadmap"
+    src="https://portal.productboard.com/lrmhupnda99qqd4uofvozs4j/tabs/9-planned"
+    frameborder="0"
+    height="700px"
+    width="100%"
+    onload="resizeRoadmap()"
+/>


### PR DESCRIPTION
Since there is no way to fit the iframe to fit its contents as it is cross-origin, we instead try to fill as much of the viewport as possible on the iframe load.