### PR TITLE
RELATED: RAIL-4337 Hide irrelevant old pages in newer versions

### DIFF
--- a/docs/10_vis__dashboard_view.md
+++ b/docs/10_vis__dashboard_view.md
@@ -1,0 +1,29 @@
+---
+ title: DashboardView
+ sidebar_label: DashboardView
+ copyright: (C) 2007-2021 GoodData Corporation
+ id: dashboard_view_component
+ ---
+
+ > **The DashboardView component has been superseded by the [Dashboard component](18_dashboard_intro.md) and will be
+ > removed in GoodData.UI Version 8.10.**
+ >
+ The [**Dashboard component**](18_dashboard_intro.md) builds up on the DashboardView component. We position it to handle the dashboard
+ rendering end-to-end. Editing capabilities may be considered in the future.
+
+ Currently, the Dashboard component provides more functionality and more APIs compared to the DashboardView component.
+ The Dashboard component:
+
+ -  Renders an entire dashboard the same way the KPI Dashboards are rendered on the GoodData platform: it includes the top bar with the title and buttons,
+    and the filter bar with date and attribute filters
+
+ -  Widens the API footprint:
+       - Includes more APIs to observe the state of the dashboard
+       - Expands on the number of events emitted by the dashboard
+       - Provides an extended set of APIs to interact with the dashboard
+
+ -  Enables customization of all elementary components used on the dashboard and allows adding custom widgets
+
+ -  Comes with the first set of fully public and stable APIs that will be compatible with changes in minor GoodData.UI versions released after Version 8.7
+
+ Check out our [roadmap](01_intro__roadmap.md) to learn more about the plans for the dashboards in GoodData.UI.

--- a/docs/10_vis__theme_provider.md
+++ b/docs/10_vis__theme_provider.md
@@ -42,7 +42,7 @@ import { ThemeProvider } from "@gooddata/sdk-ui-theme-provider";
 
 ## Using the Theme Provider component with a custom theme
 
-You can create properties of a custom theme and pass the theme to the `ThemeProvider` element that you added to your application (for all available properties, see the [declaration of ITheme](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-backend-spi/src/workspace/styling/theme.ts#L178)).
+You can create properties of a custom theme and pass the theme to the `ThemeProvider` element that you added to your application (for all available properties, see the [declaration of ITheme](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-model/src/theme/index.ts#L765)).
 
 ```jsx
 import { ThemeProvider } from "@gooddata/sdk-ui-theme-provider";

--- a/docs/50_custom__create_new_visualization.md
+++ b/docs/50_custom__create_new_visualization.md
@@ -25,11 +25,11 @@ However, for more complex scenarios (for example, when one execution depends on 
 
 - `useInsightDataView` hook allows you to fetch data for an existing insight created in [Analytical Designer](https://help.gooddata.com/pages/viewpage.action?pageId=86794494) and render it with your custom visualization.
     It fetches the result data for you and informs you about the loading status or error if there are any.
-    It is basically [InsightView](insight-view), but without the view part.
+    It is basically [InsightView](visualization_component), but without the view part.
     See example usage of this hook in the [live examples](https://gdui-examples.herokuapp.com/execute/use-insight-data-view-hook) gallery.
 
 ### React components
-- `Execute` is a component alternative to the `useExecutionDataView` hook. You can specify data to obtain with [series and slices](#access-custom-visualization-data). 
+- `Execute` is a component alternative to the `useExecutionDataView` hook. You can specify data to obtain with [series and slices](#access-custom-visualization-data).
     It fetches the result data for you and informs you about the loading status or error if there are any.
     See example usage of this component in the [live examples](https://gdui-examples.herokuapp.com/execute/execute-component) gallery.
 
@@ -40,7 +40,7 @@ However, for more complex scenarios (for example, when one execution depends on 
 - `ExecuteInsight` is a component alternative to `useInsightDataView` hook.
     It allows you to fetch data for an existing insight created in [Analytical Designer](https://help.gooddata.com/pages/viewpage.action?pageId=86794494) and render it with your custom visualization.
     It fetches the result data for you and informs you about the loading status or error if there are any.
-    It is basically [InsightView](insight-view), but without the view part.
+    It is basically [InsightView](visualization_component), but without the view part.
     See example usage of this component in the [live examples](https://gdui-examples.herokuapp.com/execute/execute-insight-component) gallery.
 
 ### Execution API

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -133,6 +133,9 @@
         "title": "Combo Chart",
         "sidebar_label": "Combo Chart"
       },
+      "10_vis__dashboard_view": {
+        "title": "10_vis__dashboard_view"
+      },
       "date_filter_component": {
         "title": "Date Filter",
         "sidebar_label": "Date Filter"

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -43,6 +43,38 @@ const siteConfig = {
   ],
   onPageNav: 'separate',
   users,
+  // specify old items to hide in newer versions, see https://v1.docusaurus.io/docs/en/site-config#deleteddocs-object
+  deletedDocs: {
+    "5.0.0": [
+      "afm_react_components",
+      "ex_global_filters",
+      "getting_started",
+      "ht_access_gd_api_directly",
+      "ht_build_app",
+      "ht_configure_webpack_proxy",
+      "ht_set_up_loading_state_for_embedded_insights",
+      "legal_notices",
+      "quick_start",
+      "react_components"
+    ],
+    "6.0.0": [
+      "glossary",
+      "ht_build_visualization_custom_react",
+      "trouble_shooting"
+    ],
+    "7.0.0": [
+      "table_totals_in_execution_object"
+    ],
+    "8.0.0": [
+      "clean_up_your_code",
+      "data_layer",
+      "execution_rest_api_and_result",
+      "table_component"
+    ],
+    "8.10.0": [
+      "dashboard_view_component"
+    ]
+  },
   /* path to images for header/footer */
   headerIcon: 'img/gooddata.svg?v=2022',
   footerIcon: 'img/gooddata.svg?v=2022',

--- a/website/versioned_docs/version-8.1.0/10_vis__theme_provider.md
+++ b/website/versioned_docs/version-8.1.0/10_vis__theme_provider.md
@@ -43,7 +43,7 @@ import { ThemeProvider } from "@gooddata/sdk-ui-theme-provider";
 
 ### Using the Theme Provider component with a custom theme
 
-You can create properties of a custom theme, and pass the theme to the `ThemeProvider` that you added to your application (for all available properties, see [the declaration of ITheme](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-backend-spi/src/workspace/styling/theme.ts#L178)).
+You can create properties of a custom theme, and pass the theme to the `ThemeProvider` that you added to your application (for all available properties, see [the declaration of ITheme](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-model/src/theme/index.ts#L765)).
 
 ```jsx
 import { ThemeProvider } from "@gooddata/sdk-ui-theme-provider";

--- a/website/versioned_docs/version-8.2.0/10_vis__theme_provider.md
+++ b/website/versioned_docs/version-8.2.0/10_vis__theme_provider.md
@@ -43,7 +43,7 @@ import { ThemeProvider } from "@gooddata/sdk-ui-theme-provider";
 
 ## Using the Theme Provider component with a custom theme
 
-You can create properties of a custom theme and pass the theme to the `ThemeProvider` element that you added to your application (for all available properties, see the [declaration of ITheme](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-backend-spi/src/workspace/styling/theme.ts#L178)).
+You can create properties of a custom theme and pass the theme to the `ThemeProvider` element that you added to your application (for all available properties, see the [declaration of ITheme](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-model/src/theme/index.ts#L765)).
 
 ```jsx
 import { ThemeProvider } from "@gooddata/sdk-ui-theme-provider";

--- a/website/versioned_docs/version-8.3.0/10_vis__theme_provider.md
+++ b/website/versioned_docs/version-8.3.0/10_vis__theme_provider.md
@@ -43,7 +43,7 @@ import { ThemeProvider } from "@gooddata/sdk-ui-theme-provider";
 
 ### Using the Theme Provider component with a custom theme
 
-You can create properties of a custom theme, and pass the theme to the `ThemeProvider` that you added to your application (for all available properties, see [the declaration of ITheme](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-backend-spi/src/workspace/styling/theme.ts#L178)).
+You can create properties of a custom theme, and pass the theme to the `ThemeProvider` that you added to your application (for all available properties, see [the declaration of ITheme](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-model/src/theme/index.ts#L765)).
 
 ```jsx
 import { ThemeProvider } from "@gooddata/sdk-ui-theme-provider";

--- a/website/versioned_docs/version-8.6.0/10_vis__theme_provider.md
+++ b/website/versioned_docs/version-8.6.0/10_vis__theme_provider.md
@@ -43,7 +43,7 @@ import { ThemeProvider } from "@gooddata/sdk-ui-theme-provider";
 
 ## Using the Theme Provider component with a custom theme
 
-You can create properties of a custom theme and pass the theme to the `ThemeProvider` element that you added to your application (for all available properties, see the [declaration of ITheme](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-backend-spi/src/workspace/styling/theme.ts#L178)).
+You can create properties of a custom theme and pass the theme to the `ThemeProvider` element that you added to your application (for all available properties, see the [declaration of ITheme](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-model/src/theme/index.ts#L765)).
 
 ```jsx
 import { ThemeProvider } from "@gooddata/sdk-ui-theme-provider";


### PR DESCRIPTION
This will avoid some confusion with people finding old irrelevant pages
using the Algolia search.

Also hide DashboardView in a way that will not break older versions and
fix some dead links.

JIRA: RAIL-4337