### PR TITLE
RELATED: RAIL-3410 Remove bad practice from Execute, hide it in SDK8

### DIFF
--- a/docs/50_custom__component.md
+++ b/docs/50_custom__component.md
@@ -40,7 +40,7 @@ The following example shows the function specified as a child in the Execution 
 ```javascript
 import { Execute, isEmptyResult } from "@gooddata/react-components";
 
-<Execute afm={<afm>} projectId={<workspace-id>} onLoadingChanged={e=>{}} onLoadingFinish={e=>{}} onError={e=>{}}>
+<Execute afm={<afm>} projectId={<workspace-id>}>
     {
         (execution) => {
             const { isLoading, error, result } = execution;

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -69,6 +69,7 @@ const siteConfig = {
       "clean_up_your_code",
       "data_layer",
       "execution_rest_api_and_result",
+      "execute_component",
       "table_component"
     ],
     "8.10.0": [

--- a/website/versioned_docs/version-5.1.0/50_custom__component.md
+++ b/website/versioned_docs/version-5.1.0/50_custom__component.md
@@ -41,7 +41,7 @@ The following example shows the function specified as a child in the Execution 
 ```javascript
 import { Execute, isEmptyResult } from '@gooddata/react-components';
 
-<Execute afm={<afm>} projectId={<workspace-id>} onLoadingChanged={e=>{}} onLoadingFinish={e=>{}} onError={e=>{}}>
+<Execute afm={<afm>} projectId={<workspace-id>}>
     {
         (execution) => {
             const { isLoading, error, result } = execution;

--- a/website/versioned_docs/version-8.0.0/50_custom__component.md
+++ b/website/versioned_docs/version-8.0.0/50_custom__component.md
@@ -41,7 +41,7 @@ The following example shows the function specified as a child in the Execution 
 ```javascript
 import { Execute, isEmptyResult } from "@gooddata/react-components";
 
-<Execute afm={<afm>} projectId={<workspace-id>} onLoadingChanged={e=>{}} onLoadingFinish={e=>{}} onError={e=>{}}>
+<Execute afm={<afm>} projectId={<workspace-id>}>
     {
         (execution) => {
             const { isLoading, error, result } = execution;


### PR DESCRIPTION
In SDK8 the page should no longer be shown as it was replaced by
a whole section about custom components.

JIRA: RAIL-3410