### PR TITLE
RELATED: RAIL-4665 Fixed invalid links in WebComponents docs

### DIFF
--- a/docs/19_webcomponents_insight.md
+++ b/docs/19_webcomponents_insight.md
@@ -76,5 +76,5 @@ You can subscribe to the events the same way as to any other DOM event:
 ```
 
 [1]:https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui/src/base/localization/Locale.ts
-[2]:https://sdk.gooddata.com/gooddata-ui/docs/visualization_component.html#properties
-[3]:19_webcomponents_authentication.md#programmatic-authentication
+[2]:19_webcomponents_authentication.md#programmatic-authentication
+[3]:https://sdk.gooddata.com/gooddata-ui/docs/visualization_component.html#properties

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -1908,6 +1908,22 @@
         "title": "Dashboard Plugins",
         "sidebar_label": "Dashboard Plugins"
       },
+      "version-8.11.0/version-8.11.0-webcomponents_authentication": {
+        "title": "Web Components authentication",
+        "sidebar_label": "Web Components authentication"
+      },
+      "version-8.11.0/version-8.11.0-webcomponents_dashboard": {
+        "title": "Dashboard custom element",
+        "sidebar_label": "Dashboard custom element"
+      },
+      "version-8.11.0/version-8.11.0-webcomponents_insight": {
+        "title": "Insight custom element",
+        "sidebar_label": "Insight custom element"
+      },
+      "version-8.11.0/version-8.11.0-webcomponents_intro": {
+        "title": "Introduction to GoodData Web Components",
+        "sidebar_label": "Introduction to GoodData Web Components"
+      },
       "version-8.11.0/version-8.11.0-create_custom_attribute_filter": {
         "title": "Create a Custom Attribute Filter",
         "sidebar_label": "Create a Custom Attribute Filter"

--- a/website/versioned_docs/version-8.11.0/19_webcomponents_insight.md
+++ b/website/versioned_docs/version-8.11.0/19_webcomponents_insight.md
@@ -77,5 +77,5 @@ You can subscribe to the events the same way as to any other DOM event:
 ```
 
 [1]:https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui/src/base/localization/Locale.ts
-[2]:https://sdk.gooddata.com/gooddata-ui/docs/visualization_component.html#properties
-[3]:19_webcomponents_authentication.md#programmatic-authentication
+[2]:19_webcomponents_authentication.md#programmatic-authentication
+[3]:https://sdk.gooddata.com/gooddata-ui/docs/visualization_component.html#properties


### PR DESCRIPTION
Two links got mixed up.

Hey, @no23reason. When I build the project to test the fix, there is also a `website/i18n/en.json` file updated. Should I commit it as well? Thanks!